### PR TITLE
Make @MicronautTest discovered when used as meta-annotation

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -22,6 +22,7 @@ import io.micronaut.test.annotation.MicronautTest;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.AbstractMicronautExtension;
 import org.junit.jupiter.api.extension.*;
+import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -38,7 +39,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
         final Class<?> testClass = extensionContext.getRequiredTestClass();
-        final MicronautTest micronautTest = testClass.getAnnotation(MicronautTest.class);
+        final MicronautTest micronautTest = AnnotationSupport.findAnnotation(testClass, MicronautTest.class).orElse(null);
         beforeClass(extensionContext, testClass, micronautTest);
     }
 
@@ -67,7 +68,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             }
         } else {
             final Class<?> testClass = extensionContext.getRequiredTestClass();
-            if (testClass.isAnnotationPresent(MicronautTest.class)) {
+            if (AnnotationSupport.isAnnotated(testClass, MicronautTest.class)) {
                 return ConditionEvaluationResult.enabled("Test bean active");
             } else {
                 return ConditionEvaluationResult.disabled(DISABLED_MESSAGE);

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationRunTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationRunTest.java
@@ -12,8 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.*;
 import javax.inject.Inject;
 
-@MicronautTest
-@ExtendWith(MockitoExtension.class)
+@MicronautAndMockitoTest
 class ApplicationRunTest {
 
     @Inject

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautAndMockitoTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautAndMockitoTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.test.junit5;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Documented
+
+@MicronautTest
+@ExtendWith(MockitoExtension.class)
+public @interface MicronautAndMockitoTest {
+}


### PR DESCRIPTION
Hello,

I found a little issue when using `@MicronautTest` as a **meta**-annotation on a test class.

For example this kind of annotation:
```java
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})

@MicronautTest
@ExtendWith(MockitoExtension.class)
public @interface MicronautAndMockitoTest {}
```

On a test class, leads to the test being ignored due to `AbstractMicronautExtension#DISABLED_MESSAGE`.

So here is a little fix 😃 