### PR TITLE
Fixes #35 JUnit ignores tests when using `@MicronautTest` in a superclass

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/annotation/MicronautTest.java
+++ b/test-core/src/main/java/io/micronaut/test/annotation/MicronautTest.java
@@ -23,10 +23,7 @@ import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 import io.micronaut.test.extensions.spock.MicronautSpockExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotation that can be applied to any Spock spec to make it a Micronaut test.
@@ -39,6 +36,7 @@ import java.lang.annotation.Target;
 @org.spockframework.runtime.extension.ExtensionAnnotation(MicronautSpockExtension.class)
 @ExtendWith(MicronautJunit5Extension.class)
 @Factory
+@Inherited
 @Requires(condition = TestActiveCondition.class)
 public @interface MicronautTest {
     /**

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/BaseTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/BaseTest.java
@@ -1,0 +1,7 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.annotation.MicronautTest;
+
+@MicronautTest
+public abstract class BaseTest {
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathInheritedTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathInheritedTest.java
@@ -1,0 +1,18 @@
+package io.micronaut.test.junit5;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+class MathInheritedTest extends BaseTest {
+
+    @Inject MathService mathService;
+
+    @Test
+    void testComputeNumToSquare() {
+        final Integer result = mathService.compute(2);
+
+        Assertions.assertEquals((Integer) 8, result);
+    }
+}


### PR DESCRIPTION
* Added `@Inherited` to MicronautTest annotation.
* Fix JUnit ignores tests when using `@MicronautTest` in a superclass.