### PR TITLE
doc: remove `@Singleton` from interface

### DIFF
--- a/test-spock/src/test/groovy/io/micronaut/test/spock/MathService.java
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/MathService.java
@@ -2,7 +2,6 @@ package io.micronaut.test.spock;
 
 import javax.inject.Singleton;
 
-@Singleton
 interface MathService {
 
     Integer compute(Integer num);


### PR DESCRIPTION
The `@Singleton` doesn't make sense in an interface.