### PR TITLE
Saves applicationContext into junit5 store

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -16,6 +16,7 @@
 package io.micronaut.test.extensions.junit5;
 
 import io.micronaut.aop.InterceptedProxy;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.FieldInjectionPoint;
@@ -40,12 +41,14 @@ import java.util.*;
  * @since 1.0
  */
 public class MicronautJunit5Extension extends AbstractMicronautExtension<ExtensionContext> implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, ExecutionCondition, BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver {
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MicronautJunit5Extension.class);
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
         final Class<?> testClass = extensionContext.getRequiredTestClass();
         final MicronautTest micronautTest = AnnotationSupport.findAnnotation(testClass, MicronautTest.class).orElse(null);
         beforeClass(extensionContext, testClass, micronautTest);
+        getStore(extensionContext).put(ApplicationContext.class, applicationContext);
         if (specDefinition != null) {
             TestInstance ti = AnnotationSupport.findAnnotation(testClass, TestInstance.class).orElse(null);
             if (ti != null && ti.value() == TestInstance.Lifecycle.PER_CLASS) {
@@ -158,5 +161,9 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         } else {
             return applicationContext.getBean(parameterContext.getParameter().getType());
         }
+    }
+
+    private static ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
     }
 }


### PR DESCRIPTION
As discussed in #145, the ApplicationContext is now being saved into JUnit5 store.

This makes it possible for other JUnit5 extensions to retrieve current application context making it easier to integrate Micronaut with other JUnit5 extensions.

With the application context available in the store I was able to retrieve the datasource in the [dbunit extension](https://github.com/database-rider/database-rider/blob/472c19b22b679dce9cc9883fd022ca3e2251e170/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java#L261) and then use it in Micronaut test, see an [example here](https://github.com/rmpestano/rider-micronaut/blob/master/src/test/java/example/repositories/PetRepositoryTest.java#L26).
 
I didn't add a test because testing [JUnit5 extensions](https://github.com/junit-team/junit5/blob/master/platform-tests/src/test/java/org/junit/platform/testkit/engine/ExecutionsIntegrationTests.java) will add more complexity to the project then benefits.