### PR TITLE
Upgrade KotlinTest to Kotest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-test
 githubBranch=master
 kotlintestVersion=3.2.1
+kotestVersion=4.0.3
 developers=Graeme Rocher
 # Not really needed for this project, but anyway
 kafkaVersion="Unknown"
@@ -15,6 +16,7 @@ grailsVersion=3.3.8
 spocktests=test-spock/src/test/groovy/io/micronaut/test/spock
 junit5tests=test-junit5/src/test/java/io/micronaut/test/junit5
 kotlintesttests=test-kotlintest/src/test/kotlin/io/micronaut/test/kotlintest
+kotesttests=test-kotest/src/test/kotlin/io/micronaut/test/kotest
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048M
 org.gradle.parallel=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,5 @@ rootProject.name = 'micronaut-test'
 include 'test-core'
 include "test-spock"
 include "test-junit5"
+include "test-kotest"
 include "test-kotlintest"

--- a/src/main/docs/guide/kotest.adoc
+++ b/src/main/docs/guide/kotest.adoc
@@ -1,0 +1,323 @@
+=== Setting up Kotest
+
+To get started using Kotest you need the following dependencies in your build configuration:
+
+.build.gradle
+[source,groovy,subs="attributes"]
+----
+dependencies {
+    kaptTest "io.micronaut:micronaut-inject-java"
+    testImplementation "io.micronaut.test:micronaut-test-kotest:{version}"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "io.kotest:kotest-runner-junit5-jvm:4.0.3"
+}
+
+// use JUnit 5 platform
+test {
+    useJUnitPlatform()
+}
+----
+
+Or for Maven:
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>io.micronaut.test</groupId>
+    <artifactId>micronaut-test-kotest</artifactId>
+    <version>{version}</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>io.mockk</groupId>
+    <artifactId>mockk</artifactId>
+    <version>1.9.3</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>io.kotest</groupId>
+    <artifactId>kotest-runner-junit5-jvm</artifactId>
+    <version>4.0.3</version>
+    <scope>test</scope>
+</dependency>
+----
+
+Note that for Maven you will also need to configure the Surefire plugin to use JUnit platform and configure the kotlin maven plugin:
+
+.pom.xml
+[source,xml]
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>2.22.2</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.3.1</version>
+        </dependency>
+    </dependencies>
+</plugin>
+<plugin>
+    <artifactId>kotlin-maven-plugin</artifactId>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <version>1.3.20</version>
+    <configuration>
+        <compilerPlugins>
+            <plugin>all-open</plugin>
+        </compilerPlugins>
+        <pluginOptions>
+            <option>all-open:annotation=io.micronaut.aop.Around</option>
+        </pluginOptions>
+    </configuration>
+    <executions>
+        <execution>
+            <id>kapt</id>
+            <goals>
+                <goal>kapt</goal>
+            </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.baseDir}/src/main/kotlin</sourceDir>
+                </sourceDirs>
+                <annotationProcessorPaths>
+                    <annotationProcessorPath>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-inject-java</artifactId>
+                        <version>${micronaut.version}</version>
+                    </annotationProcessorPath>
+                    <annotationProcessorPath>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-validation</artifactId>
+                        <version>${micronaut.version}</version>
+                    </annotationProcessorPath>
+                </annotationProcessorPaths>
+            </configuration>
+        </execution>
+        <execution>
+            <id>compile</id>
+            <goals>
+                <goal>compile</goal>
+            </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                </sourceDirs>
+            </configuration>
+        </execution>
+        <execution>
+            <id>test-kapt</id>
+            <goals>
+                <goal>test-kapt</goal>
+            </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>src/test/kotlin</sourceDir>
+                </sourceDirs>
+                <annotationProcessorPaths>
+                    <annotationProcessorPath>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-inject-java</artifactId>
+                        <version>${micronaut.version}</version>
+                    </annotationProcessorPath>
+                </annotationProcessorPaths>
+            </configuration>
+        </execution>
+        <execution>
+            <id>test-compile</id>
+            <goals>
+                <goal>test-compile</goal>
+            </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                    <sourceDir>${project.basedir}/target/generated-sources/kapt/test</sourceDir>
+                </sourceDirs>
+            </configuration>
+        </execution>
+    </executions>
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-allopen</artifactId>
+            <version>${kotlinVersion}</version>
+        </dependency>
+    </dependencies>
+</plugin>
+----
+
+=== Before You Begin
+
+Before you can get started writing tests with Kotest, it is necessary to inform Kotest of the Micronaut extensions. The way to do that is by providing a `ProjectConfig`. Here is how to do so for Micronaut Test:
+
+[source,kotlin]
+----
+include::test-kotest/src/test/kotlin/io/micronaut/test/kotest/ProjectConfig.kt[]
+----
+
+=== Writing a Micronaut Test with Kotest
+
+Let's take a look at an example using Kotest. Consider you have the following interface:
+
+.The MathService Interface
+[source,kotlin]
+----
+include::{kotesttests}/MathService.kt[]
+----
+
+And a simple implementation that computes the value times 4 and is defined as Micronaut bean:
+
+.The MathService implementation
+[source,kotlin]
+----
+include::{kotesttests}/MathServiceImpl.kt[]
+----
+
+You can define the following test to test the implementation:
+
+.The MathService specification
+[source,groovy]
+----
+include::{kotesttests}/MathServiceTest.kt[]
+----
+
+<1> The test is declared as Micronaut test with `@MicronautTest`
+<2> The constructor is used to inject the bean
+<3> The test itself tests the injected bean
+
+
+=== Environments, Classpath Scanning etc.
+
+The `@MicronautTest` annotation supports specifying the environment names the test should run with:
+
+```java
+@MicronautTest(environments={"foo", "bar"})
+```
+
+In addition, although Micronaut itself doesn't scan the classpath, some integrations do (such as JPA and GORM), for these cases you may wish to specify either the application class:
+
+```java
+@MicronautTest(application=Application.class)
+```
+
+Or the packages:
+
+```java
+@MicronautTest(packages="foo.bar")
+```
+
+To ensure that entities can be found during classpath scanning.
+
+=== Using Mockk Mocks
+
+Now let's say you want to replace the implementation with a Mockk. You can do so by defining a method that returns a mock and is annotated with `@MockBean`, for example:
+
+.The MathService specification
+[source,kotlin]
+----
+include::{kotesttests}/MathMockServiceTest.kt[]
+----
+
+<1> The `@MockBean` annotation is used to indicate the method returns a mock bean. The value to the method is the type being replaced.
+<2> Mockk's `mockk(..)` method creates the actual mock
+<3> The math service proxy is injected into the test
+<4> The call to `getMock` is used to retrieve the underlying mock
+<5> Mockk is used to verify the mock is called
+
+Note that because the bean is a method of the test, it will be active only for the scope of the test. This approach allows you to define beans that are isolated per test class.
+
+IMPORTANT: Because Kotlin uses constructor injection, it's not possible to automatically replace the mock proxy with the mock implementation as is done with the other test implementations. The `getMock` method was created to make retrieving the underlying mock object easier.
+
+=== Mocking Collaborators
+
+Note that in most cases you won't define a `@MockBean` and then inject it only to verify interaction with the Mock directly, instead the Mock will be a collaborator within your application. For example say you have a `MathController`:
+
+.The MathController
+[source,kotlin]
+----
+include::{kotesttests}/MathController.kt[]
+----
+
+The above controller uses the `MathService` to expose a `/math/compute/{number}` endpoint. See the following example for a test that tests interaction with the mock collaborator:
+
+.Mocking Collaborators
+[source,kotlin]
+----
+include::{kotesttests}/MathCollaboratorTest.kt[]
+----
+
+<1> Like the previous example a Mock is defined using `@MockBean`
+<2> This time we inject an instance of `RxHttpClient` to test the controller.
+<3> We invoke the controller and retrieve the result
+<4> The interaction with mock collaborator is verified.
+
+The way this works is that `@MicronautTest` will inject a proxy that points to the mock instance. For each iteration of the test the mock is refreshed (in fact it uses Micronaut's built in `RefreshScope`).
+
+=== Using `@Requires` on Tests
+
+Since `@MicronautTest` turns tests into beans themselves, it means you can use the `@Requires` annotation on the test to enable/disable tests. For example:
+
+[source,kotlin]
+----
+@MicronautTest
+@Requires(env = "my-env")
+class RequiresTest {
+    ...
+}
+----
+
+The above test will only run if `my-env` is active (you can active it by passing the system property `micronaut.environments`).
+
+=== Defining Additional Test Specific Properties
+
+You can define additional test specific properties using the `@Property` annotation. The following example demonstrates usage:
+
+.Using `@Property`
+[source,kotlin]
+----
+include::{kotesttests}/PropertyValueTest.kt[]
+----
+
+Alternatively you can specify additional `propertySources` in any supported format (YAML, JSON, Java properties file etc.) using the `@MicronautTest` annotation:
+
+.Using `propertySources` stored in files
+[source,kotlin]
+----
+include::{kotesttests}/PropertySourceTest.kt[]
+----
+
+The above example expects a file located at `src/test/resources/io/micronaut/kotest/myprops.properties`. You can however use a prefix to indicate where the file should be searched for. The following are valid values:
+
+* `file:myprops.properties` - A relative path to a file somewhere on the file system
+* `classpath:myprops.properties` - A file relative to the root of the classpath
+* `myprops.properties` - A file relative on the classpath relative to the test being run.
+
+NOTE: Because Kotlin doesn't support multiple annotations, the `@PropertySource` annotation must be used to define multiple properties.
+
+=== Constructor Injection Caveats
+
+There are a couple caveats to using constructor injection to be aware of.
+
+1. In order for `TestPropertyProvider` to work, test classes must have not have any constructor arguments. This is because the class needs constructed prior to bean creation in order to add the properties to the context. Fields and methods will still be injected.
+
+1. `@Requires()` cannot be used with constructor injection because Kotest requires the instance to be created regardless if the test should be ignored or not. If the requirements disable the bean, it cannot be created from the context and thus construction responsibility will be delegated to the default behavior.
+
+=== Refreshing injected beans based on `@Requires` upon properties changes
+
+You can use combine the use of `@Requires` and `@Property`, so that injected beans will be refreshed if there are
+configuration changes that affect their `@Requires` condition.
+
+For that to work, the test must be annotated with `@MicronautTest(rebuildContext = true)`. In that case, if there are
+changes in any property for a given test, the application context will be rebuilt so that `@Requires` conditions are
+re-evaluated again.
+
+For example:
+
+.Combining `@Requires` and `@Property` in a `@Refreshable` test class.
+[source,kotlin]
+----
+include::{kotesttests}/PropertyValueRequiresTest.kt[]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,5 +3,6 @@ introduction:
 spock: Testing with Spock
 junit5: Testing with JUnit 5
 kotlintest: Testing with KotlinTest
+kotest: Testing with Kotest
 #spek: Testing with Spek
 repository: Repository

--- a/test-kotest/build.gradle
+++ b/test-kotest/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm" version "1.3.71"
+    id "org.jetbrains.kotlin.kapt" version "1.3.71"
+}
+
+ext {
+    micronautHibernateJpaVersion = "1.3.0"
+    micronautJdbcTomcatVersion = "1.3.0"
+    kotlinVersion = "1.3.71"
+}
+
+dependencies {
+    api project(":test-core")
+    implementation "io.micronaut:micronaut-inject:$micronautVersion"
+    api "io.micronaut:micronaut-runtime:$micronautVersion"    
+    api "io.kotest:kotest-runner-junit5-jvm:$kotestVersion"
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"
+    testImplementation "io.micronaut:micronaut-http-server-netty:$micronautVersion"
+    kaptTest "io.micronaut:micronaut-inject-java:$micronautVersion"
+
+    testImplementation "io.micronaut.configuration:micronaut-hibernate-jpa:$micronautHibernateJpaVersion"
+    testRuntimeOnly "io.micronaut.configuration:micronaut-jdbc-tomcat:$micronautJdbcTomcatVersion"
+    testRuntimeOnly "com.h2database:h2:1.4.200"
+    
+    testImplementation "io.kotest:kotest-assertions-core-jvm:$kotestVersion"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = '1.8'
+        javaParameters = true
+    }
+}

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5
+
+import org.junit.jupiter.api.extension.Extension
+
+/**
+ * This class is necessary because `test-core` declares it as part of the class annotation, at
+ * `io.micronaut.test.annotation.MicronautTest`. It's removed from the classpath from commit
+ * 0cf54bfbca0aa0f9ec39ed4cea31375ba7e1e441 on.
+ *
+ * When Kotest tries to initialize the spec, `io.micronaut.test.annotation::findRepeatableAnnotations` would throw an
+ * exception because `MicronautJunit5Extension` won't be on the classpath.
+ *
+ * This small hack adds it to the classpath and hides it via the `internal`. It's not an issue as users from Kotest
+ * won't use MicronautJunit5Extension anyway.
+ */
+internal class MicronautJunit5Extension : Extension 

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.kotest
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.AbstractMicronautExtension
+import io.micronaut.test.support.TestPropertyProvider
+import kotlin.reflect.full.memberFunctions
+
+class MicronautKotestContext(private val testClass: Class<Any>,
+                             private val micronautTest: MicronautTest,
+                             private val createBean: Boolean) : AbstractMicronautExtension<Spec>() {
+
+    override fun resolveTestProperties(context: Spec?, testAnnotation: MicronautTest?, testProperties: MutableMap<String, Any>?) {
+        if (context is TestPropertyProvider) {
+            testProperties?.putAll(context.properties)
+        }
+    }
+
+    val bean : Spec?
+
+    init {
+        bean = if (createBean) {
+            beforeClass(null, testClass, micronautTest)
+            applicationContext.findBean(testClass).orElse(null) as Spec?
+        } else {
+            null
+        }
+    }
+
+    override fun alignMocks(context: Spec?, instance: Any) {
+    }
+
+    fun beforeSpecClass(spec: Spec) {
+        if (!createBean) {
+            beforeClass(spec, testClass, micronautTest)
+            applicationContext.inject(spec)
+        }
+    }
+
+    fun afterSpecClass(spec: Spec) {
+        afterClass(spec)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun beforeTest(testCase: TestCase) {
+        var filter = testCase.spec::class.memberFunctions.filter { it.name == testCase.name }
+        var propertyAnnotations: List<Property>? = emptyList()
+        if (filter.isNotEmpty()) {
+            propertyAnnotations = filter.first().annotations.filter { it is Property } as? List<Property>
+        }
+        beforeEach(testCase.spec, testCase.spec, testCase.test.javaClass, propertyAnnotations)
+        begin()
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun afterTest(testCase: TestCase) {
+        commit()
+        rollback()
+    }
+
+    fun getSpecDefinition() = specDefinition
+}

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
@@ -13,71 +13,66 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.test.extensions.kotlintest
+package io.micronaut.test.extensions.kotest
 
-import io.kotlintest.Spec
-import io.kotlintest.TestCase
-import io.kotlintest.TestResult
-import io.kotlintest.extensions.ConstructorExtension
-import io.kotlintest.extensions.TestCaseExtension
-import io.kotlintest.extensions.TestListener
-import io.kotlintest.extensions.TopLevelTest
+import io.kotest.core.extensions.ConstructorExtension
+import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.micronaut.aop.InterceptedProxy
 import io.micronaut.test.annotation.MicronautTest
-import org.junit.platform.commons.support.AnnotationSupport
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 
-@Deprecated(
-    "KotlinTest is now deprecated in favor of Kotest (KotlinTest's 4.0.0 version). Upgrade to Kotest is recommended."
-)
-object MicronautKotlinTestExtension: TestListener, ConstructorExtension, TestCaseExtension {
+object MicronautKotestExtension: TestListener, ConstructorExtension, TestCaseExtension {
 
-
-    override suspend fun intercept(testCase: TestCase,
-                                   execute: suspend (TestCase, suspend (TestResult) -> Unit) -> Unit,
-                                   complete: suspend (TestResult) -> Unit) {
+    override suspend fun intercept(
+        testCase: TestCase,
+        execute: suspend (TestCase) -> TestResult
+    ): TestResult {
         val context = contexts[testCase.spec.javaClass.name]
-        if (context != null && context.getSpecDefinition() == null) {
-            //Its a MicronautTest test where the bean doesn't exist
-            complete(TestResult.Ignored)
+        return if(context != null && context.getSpecDefinition() == null) {
+            // It's a MicronautTest test where the bean doesn't exist
+            TestResult.Ignored
         } else {
-            //Not a MicronautTest test or the bean exists
-            execute(testCase, complete)
+            // Not a MicronautTest test or the bean exists
+            execute(testCase)
         }
     }
 
-    val contexts: MutableMap<String, MicronautKotlinTestContext> = mutableMapOf()
+    val contexts: MutableMap<String, MicronautKotestContext> = mutableMapOf()
 
-    override fun beforeSpecClass(spec: Spec, tests: List<TopLevelTest>) {
+    override suspend fun beforeSpec(spec: Spec) {
         contexts[spec.javaClass.name]?.beforeSpecClass(spec)
     }
 
-    override fun afterSpecClass(spec: Spec, results: Map<TestCase, TestResult>) {
+    override suspend fun afterSpec(spec: Spec) {
         contexts[spec.javaClass.name]?.afterSpecClass(spec)
     }
 
-    override fun beforeTest(testCase: TestCase) {
+    override suspend fun beforeTest(testCase: TestCase) {
         contexts[testCase.spec.javaClass.name]?.beforeTest(testCase)
     }
 
-    override fun afterTest(testCase: TestCase, result: TestResult) {
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
         contexts[testCase.spec.javaClass.name]?.afterTest(testCase)
     }
+    
+    
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
-        // we only instantiate via spring if there's actually parameters in the constructor
-        // otherwise there's nothing to inject there
         val constructor = clazz.primaryConstructor
         val testClass: Class<Any> = clazz.java as Class<Any>
-        val micronautTest = AnnotationSupport.findAnnotation<MicronautTest>(testClass, MicronautTest::class.java).orElse(null)
+        val micronautTest = testClass.annotations.filterIsInstance<MicronautTest>().firstOrNull()
 
         return if (micronautTest == null) {
             null
         } else {
             val createBean = constructor != null && constructor.parameters.isNotEmpty()
-            val context = MicronautKotlinTestContext(testClass, micronautTest, createBean)
+            val context = MicronautKotestContext(testClass, micronautTest, createBean)
             contexts[testClass.name] = context
             if (createBean) {
                 context.bean
@@ -98,4 +93,4 @@ object MicronautKotlinTestExtension: TestListener, ConstructorExtension, TestCas
 }
 
 @Deprecated(message = "MicornautKotlinTestExtension is deprecated", replaceWith = ReplaceWith("MicronautKotlinTestExtension"))
-typealias MicornautKotlinTestExtension = MicronautKotlinTestExtension
+typealias MicornautKotlinTestExtension = MicronautKotestExtension

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/spock/MicronautSpockExtension.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/spock/MicronautSpockExtension.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.spock
+
+/**
+ * This class is necessary because `test-core` declares it as part of the class annotation, at 
+ * `io.micronaut.test.annotation.MicronautTest`. It's removed from the classpath from commit
+ * 0cf54bfbca0aa0f9ec39ed4cea31375ba7e1e441 on.
+ *
+ * When Kotest tries to initialize the spec, `io.micronaut.test.annotation::findRepeatableAnnotations` would throw an
+ * exception because `MicronautSpockExtension` won't be on the classpath.
+ * 
+ * This small hack adds it to the classpath and hides it via the `internal`. It's not an issue as users from Kotest
+ * won't use MicronautSpockExtension anyway.
+ */
+internal class MicronautSpockExtension 

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ApplicationRunAnotherTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ApplicationRunAnotherTest.kt
@@ -1,0 +1,62 @@
+package io.micronaut.test.kotest;
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@MicronautTest
+class ApplicationRunAnotherTest(
+        @Client("/") private val client: RxHttpClient,
+        private val testService: TestService): BehaviorSpec({
+
+    val specName = javaClass.simpleName
+
+    given("testPingServer") {
+        `when`("the mock is setup") {
+            val mock = getMock(testService)
+
+            every { mock.doStuff() } returns "mocked by $specName"
+
+            val response = client.toBlocking().retrieve(
+                    HttpRequest.GET<String>("/test"), String::class.java)
+
+            then("the response comes from the mock") {
+                response shouldBe "mocked by ApplicationRunAnotherTest"
+                verify {
+                    mock.doStuff()
+                }
+            }
+        }
+
+        `when`("the mock is changed") {
+            val mock = getMock(testService)
+
+            every { mock.doStuff() } returns "changed by $specName"
+
+            val response = client.toBlocking().retrieve(
+                    HttpRequest.GET<String>("/test"), String::class.java)
+
+            then("the mock was changed") {
+                response shouldBe "changed by ApplicationRunAnotherTest"
+                verify {
+                    mock.doStuff()
+                }
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(DefaultTestService::class)
+    fun testService(): TestService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/Book.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/Book.kt
@@ -1,0 +1,15 @@
+package io.micronaut.test.kotest
+
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+
+@Entity
+class Book {
+
+    @GeneratedValue
+    @Id
+    var id: Long? = null
+
+    var title: String? = null
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ConstructorPropertyTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ConstructorPropertyTest.kt
@@ -1,0 +1,21 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Property(name = "foo.bar", value = "3")
+class ConstructorPropertyTest(
+        @Value("\${foo.bar}") private val value: Int,
+        @Property(name = "foo.bar") private val property: Int
+): StringSpec({
+
+  "test the values are injected"() {
+      value shouldBe 3
+      property shouldBe 3
+  }
+
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DbProperties.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DbProperties.kt
@@ -1,0 +1,13 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS, AnnotationTarget.FILE)
+@MustBeDocumented
+@PropertySource(
+        Property(name = "datasources.default.name", value = "testdb"),
+        Property(name = "jpa.default.properties.hibernate.hbm2ddl.auto", value = "update")
+)
+annotation class DbProperties

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DefaultTestService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DefaultTestService.kt
@@ -1,0 +1,11 @@
+package io.micronaut.test.kotest
+
+import javax.inject.Singleton
+
+@Singleton
+class DefaultTestService : TestService {
+
+    override fun doStuff(): String {
+        return "original"
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/EmptyConstructorTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/EmptyConstructorTest.kt
@@ -1,0 +1,18 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import javax.inject.Inject
+
+@MicronautTest
+class EmptyConstructorTest: StringSpec() {
+
+    @Inject lateinit var mathService: MathService
+
+    init {
+        "test should be called" {
+            mathService.compute(1) shouldBe 4
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaNoRollbackTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaNoRollbackTest.kt
@@ -1,0 +1,61 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.test.annotation.MicronautTest
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.DefaultTransactionDefinition
+import javax.persistence.EntityManager
+
+@MicronautTest(rollback = false)
+@DbProperties
+class JpaNoRollbackTest(
+    private val entityManager: EntityManager,
+    private val transactionManager: PlatformTransactionManager
+) : BehaviorSpec() {
+
+    init {
+        given("no rollback between tests") {
+            `when`("test persist one") {
+                val book = Book()
+                book.title = "The Stand"
+                entityManager.persist(book)
+
+                then("the book is persisted") {
+                    entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                    val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                    query.from(Book::class.java)
+                    entityManager.createQuery(query).resultList.size shouldBe 1
+                }
+            }
+        }
+
+        given("a new transaction") {
+            `when`("test persist two") {
+                val book = Book()
+                book.title = "The Shining"
+                entityManager.persist(book)
+
+                then("the book is persisted") {
+                    entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                    val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                    query.from(Book::class.java)
+                    entityManager.createQuery(query).resultList.size shouldBe 2
+                }
+            }
+        }
+    }
+
+    override fun afterSpec(spec: Spec) {
+        val tx = transactionManager.getTransaction(DefaultTransactionDefinition())
+        val criteriaBuilder = entityManager.criteriaBuilder
+        val delete = criteriaBuilder.createCriteriaDelete(Book::class.java)
+        delete.from(Book::class.java)
+        entityManager.createQuery(delete).executeUpdate()
+        transactionManager.commit(tx)
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaRollbackTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaRollbackTest.kt
@@ -1,0 +1,47 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.test.annotation.MicronautTest
+import org.springframework.transaction.PlatformTransactionManager
+
+import javax.persistence.EntityManager
+
+@MicronautTest
+@DbProperties
+class JpaRollbackTest(private val entityManager: EntityManager,
+                      private val transactionManager: PlatformTransactionManager): BehaviorSpec({
+
+    given("rollback between tests") {
+        `when`("test persist one") {
+            val book = Book()
+            book.title = "The Stand"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 1
+            }
+        }
+    }
+
+    given("a new transaction") {
+        `when`("test persist two") {
+            val book = Book()
+            book.title = "The Shining"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 1
+            }
+        }
+    }
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathCollaboratorTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathCollaboratorTest.kt
@@ -1,0 +1,48 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+@MicronautTest
+class MathCollaboratorTest(
+    private val mathService: MathService,
+    @Client("/") private val client: RxHttpClient // <2>
+) : StringSpec({
+
+    "test compute num to square" {
+        val mock = getMock(mathService)
+
+        every { mock.compute(any()) } answers {
+            firstArg<Int>().toDouble().pow(2).roundToInt()
+        }
+
+        forAll(
+            row(2, 4),
+            row(3, 9)
+        ) { a: Int, b: Int ->
+            val result = client.toBlocking().retrieve("/math/compute/$a", Int::class.java) // <3>
+            result shouldBe b
+            verify { mock.compute(a) } // <4>
+        }
+
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class) // <1>
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathController.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathController.kt
@@ -1,0 +1,14 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/math")
+class MathController internal constructor(internal var mathService: MathService) {
+
+    @Get(uri = "/compute/{number}", processes = [MediaType.TEXT_PLAIN])
+    internal fun compute(number: Int): String {
+        return mathService.compute(number).toString()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathInnerService2Test.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathInnerService2Test.kt
@@ -1,0 +1,37 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+
+@MicronautTest
+class MathInnerService2Test(
+    private val mathService: MathService,
+    private val services: Array<MathService>
+) : BehaviorSpec({
+
+    given("an inner class mock") {
+
+        `when`("the mock is called") {
+            val result = mathService.compute(10)
+
+            then("the mock is used") {
+                result shouldBe 50
+                mathService is MyService
+                services.size shouldBe 1
+            }
+
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    open class MyService : MathService {
+
+        override fun compute(num: Int): Int {
+            return num * 5
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockService2Test.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockService2Test.kt
@@ -1,0 +1,28 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.mockk.mockk
+
+@MicronautTest
+class MathMockService2Test(
+    private val mathServices: Array<MathService>
+) : BehaviorSpec({
+
+    given("an array of services") {
+        `when`("the services are injected") {
+            then("the array contains a single service") {
+                mathServices.size shouldBe 1
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockServiceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockServiceTest.kt
@@ -1,0 +1,41 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+@MicronautTest
+class MathMockServiceTest(
+    private val mathService: MathService // <3>
+) : BehaviorSpec({
+
+    given("test compute num to square") {
+
+        `when`("the mock is provided") {
+            val mock = getMock(mathService) // <4>
+            every { mock.compute(any()) } answers {
+                firstArg<Int>().toDouble().pow(2).roundToInt()
+            }
+
+            then("the mock implementation is used") {
+                mock.compute(3) shouldBe 9
+                verify { mock.compute(3) } // <5>
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class) // <1>
+    fun mathService(): MathService {
+        return mockk() // <2>
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathService.kt
@@ -1,0 +1,7 @@
+package io.micronaut.test.kotest
+
+interface MathService {
+
+    fun compute(num: Int): Int
+}
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceImpl.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceImpl.kt
@@ -1,0 +1,11 @@
+package io.micronaut.test.kotest
+
+import javax.inject.Singleton
+
+@Singleton
+internal class MathServiceImpl : MathService {
+
+    override fun compute(num: Int): Int {
+        return num * 4
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTest.kt
@@ -1,0 +1,28 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest // <1>
+class MathServiceTest(
+    private val mathService: MathService // <2>
+) : BehaviorSpec({
+
+    given("the math service") {
+
+        `when`("the service is called with 2") {
+            val result = mathService.compute(2) // <3>
+            then("the result is 8") {
+                result shouldBe 8
+            }
+        }
+
+        `when`("the service is called with 3") {
+            val result = mathService.compute(3)
+            then("the result is 12") {
+                result shouldBe 12
+            }
+        }
+    }
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTestSimilarNameTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTestSimilarNameTest.kt
@@ -1,0 +1,34 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@MicronautTest
+class MathServiceTestSimilarNameTest(private val mathService: MathService) : BehaviorSpec({
+
+    given("test similarly named test suites dont leak mocks") {
+
+        `when`("the mock is provided") {
+            val mock = getMock(mathService)
+            every { mock.compute(10) } returns 20
+
+            then("the mock is used") {
+                mock.compute(10) shouldBe 20
+                verify { mock.compute(10) }
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ProjectConfig.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension
+
+object ProjectConfig : AbstractProjectConfig() {
+    override fun listeners() = listOf(MicronautKotestExtension)
+    override fun extensions() = listOf(MicronautKotestExtension)
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertySourceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertySourceTest.kt
@@ -1,0 +1,23 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest(propertySources = ["myprops.properties"])
+@Property(name = "supplied.value", value = "hello")
+class PropertySourceTest(@Property(name = "foo.bar") val value: String,
+                         @Property(name = "supplied.value") val suppliedValue: String) : BehaviorSpec({
+
+    given("a property source") {
+        `when`("the value is injected") {
+            then("the correct value is injected") {
+                value shouldBe "foo"
+                suppliedValue shouldBe "hello"
+            }
+        }
+    }
+
+})
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueRequiresTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueRequiresTest.kt
@@ -1,0 +1,44 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.annotation.MicronautTest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MicronautTest(rebuildContext = true)
+@Property(name = "foo.bar", value = "stuff")
+class PropertyValueRequiresTest: AnnotationSpec() {
+
+    @Inject
+    lateinit var myService: MyService
+
+    @Test
+    fun testInitialValue() {
+        myService.shouldBeInstanceOf<MyServiceStuff>()
+    }
+
+    @Property(name = "foo.bar", value = "changed")
+    @Test
+    fun testValueChanged() {
+        myService.shouldBeInstanceOf<MyServiceChanged>()
+    }
+
+    @Test
+    fun testValueRestored() {
+        myService.shouldBeInstanceOf<MyServiceStuff>()
+    }
+}
+
+interface MyService
+
+@Singleton
+@Requires(property = "foo.bar", value = "stuff")
+open class MyServiceStuff : MyService
+
+
+@Singleton
+@Requires(property = "foo.bar", value = "changed")
+open class MyServiceChanged : MyService

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueTest.kt
@@ -1,0 +1,31 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Property(name = "foo.bar", value = "stuff")
+class PropertyValueTest: AnnotationSpec() {
+
+    @Value("\${foo.bar}")
+    lateinit var value: String
+
+    @Test
+    fun testInitialValue() {
+        value shouldBe "stuff"
+    }
+
+    @Property(name = "foo.bar", value = "changed")
+    @Test
+    fun testValueChanged() {
+        value shouldBe "changed"
+    }
+
+    @Test
+    fun testValueRestored() {
+        value shouldBe "stuff"
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/RequiresTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/RequiresTest.kt
@@ -1,0 +1,16 @@
+package io.micronaut.test.kotest
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.BehaviorSpec
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Requires(property = "does.not.exist")
+class RequiresTest: BehaviorSpec({
+
+    given("a test with requires") {
+        fail("Should never be executed")
+    }
+
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/SimpleTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/SimpleTest.kt
@@ -1,0 +1,14 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+
+class SimpleTest: StringSpec() {
+
+    init {
+        "test should be called"() {
+            1 shouldBe 1
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestController.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestController.kt
@@ -1,0 +1,13 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/test")
+class TestController constructor(private val testService: TestService) {
+
+    @Get
+    fun index(): String {
+        return testService.doStuff()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestPropertiesProviderTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestPropertiesProviderTest.kt
@@ -1,0 +1,26 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import javax.inject.Inject
+
+@MicronautTest
+class TestPropertiesProviderTest: StringSpec(), TestPropertyProvider {
+
+    override fun getProperties(): MutableMap<String, String> {
+        return mutableMapOf("foo.bar" to "3")
+    }
+
+    @set:Inject
+    @setparam:Property(name = "foo.bar")
+    var property: Int = 0
+
+    init {
+        "test the property was injected"() {
+            property shouldBe 3
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestService.kt
@@ -1,0 +1,6 @@
+package io.micronaut.test.kotest
+
+interface TestService {
+
+    fun doStuff(): String
+}

--- a/test-kotest/src/test/resources/io/micronaut/test/kotest/myprops.properties
+++ b/test-kotest/src/test/resources/io/micronaut/test/kotest/myprops.properties
@@ -1,0 +1,1 @@
+foo.bar=foo

--- a/test-kotest/src/test/resources/logback.xml
+++ b/test-kotest/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!--<logger name="io.micronaut.context" level="trace" />-->
+</configuration>


### PR DESCRIPTION
Hello my good people! I'm one of the contributors to [Kotest](github.com/kotest/kotest), and I want to upgrade our integration with Micronaut.

KotlinTest is now known as Kotest due to the recent 4.0.0 release. This
commit adapts the current KotlinTest extension to Kotest, and deprecate
the former.

Please take a careful look at both `MicronautJunit5Extension` and `MicronautSpockExtension`, as we had to add a small workaround to these classes, as they weren't present in the classpath, but were expected to be.