### PR TITLE
Add support for kotest 4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ kafkaVersion="Unknown"
 grailsVersion=3.3.8
 spocktests=test-spock/src/test/groovy/io/micronaut/test/spock
 junit5tests=test-junit5/src/test/java/io/micronaut/test/junit5
+kotesttests=test-kotest/src/test/kotlin/io/micronaut/test/kotest
 kotlintesttests=test-kotlintest/src/test/kotlin/io/micronaut/test/kotlintest
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048M

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,5 @@ rootProject.name = 'micronaut-test'
 include 'test-core'
 include "test-spock"
 include "test-junit5"
+include "test-kotest"
 include "test-kotlintest"

--- a/test-kotest/build.gradle
+++ b/test-kotest/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm" version "1.3.72"
+    id "org.jetbrains.kotlin.kapt" version "1.3.72"
+}
+
+ext {
+    micronautHibernateJpaVersion = "1.3.0"
+    micronautJdbcTomcatVersion = "1.3.0"
+    kotlinVersion = "1.3.71"
+}
+
+dependencies {
+    api project(":test-junit5") // TODO: why is junit5 necessary here but test-kotlintest needs only core?
+    implementation "io.micronaut:micronaut-inject:$micronautVersion"
+    api "io.micronaut:micronaut-runtime:$micronautVersion"
+    api 'io.kotest:kotest-runner-junit5-jvm:4.0.5'
+    api 'io.kotest:kotest-assertions-core-jvm:4.0.5'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"
+    testImplementation "io.micronaut:micronaut-http-server-netty:$micronautVersion"
+    kaptTest "io.micronaut:micronaut-inject-java:$micronautVersion"
+
+    testImplementation "io.micronaut.configuration:micronaut-hibernate-jpa:$micronautHibernateJpaVersion"
+    testRuntimeOnly "io.micronaut.configuration:micronaut-jdbc-tomcat:$micronautJdbcTomcatVersion"
+    testRuntimeOnly "com.h2database:h2:1.4.200"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = '1.8'
+        javaParameters = true
+    }
+}

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.kotest
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.AbstractMicronautExtension
+import io.micronaut.test.support.TestPropertyProvider
+import kotlin.reflect.full.memberFunctions
+
+class MicronautKotestContext(private val testClass: Class<Any>,
+                             private val micronautTest: MicronautTest,
+                             private val createBean: Boolean) : AbstractMicronautExtension<Spec>() {
+
+    override fun resolveTestProperties(context: Spec?, testAnnotation: MicronautTest?, testProperties: MutableMap<String, Any>?) {
+        if (context is TestPropertyProvider) {
+            testProperties?.putAll(context.properties)
+        }
+    }
+
+    val bean : Spec?
+
+    init {
+        bean = if (createBean) {
+            beforeClass(null, testClass, micronautTest)
+            applicationContext.findBean(testClass).orElse(null) as Spec?
+        } else {
+            null
+        }
+    }
+
+    override fun alignMocks(context: Spec?, instance: Any) {
+    }
+
+    fun beforeSpec(spec: Spec) {
+        if (!createBean) {
+            beforeClass(spec, testClass, micronautTest)
+            applicationContext.inject(spec)
+        }
+    }
+
+    fun afterSpec(spec: Spec) {
+        afterClass(spec)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun beforeTest(testCase: TestCase) {
+        var filter = testCase.spec::class.memberFunctions.filter { it.name == testCase.name }
+        var propertyAnnotations: List<Property>? = emptyList()
+        if (filter.isNotEmpty()) {
+            propertyAnnotations = filter.first().annotations.filter { it is Property } as? List<Property>
+        }
+        beforeEach(testCase.spec, testCase.spec, testCase.test.javaClass, propertyAnnotations)
+        begin()
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun afterTest(testCase: TestCase) {
+        commit()
+        rollback()
+    }
+
+    fun getSpecDefinition() = specDefinition
+}

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.kotest
+
+import io.kotest.core.extensions.ConstructorExtension
+import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.test.annotation.MicronautTest
+import org.junit.platform.commons.support.AnnotationSupport
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+object MicronautKotestExtension: TestListener, ConstructorExtension, TestCaseExtension {
+
+   override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
+       val context = contexts[testCase.spec.javaClass.name]
+       return if (context != null && context.getSpecDefinition() == null) {
+         //Its a MicronautTest test where the bean doesn't exist
+         TestResult.Ignored
+       } else {
+         //Not a MicronautTest test or the bean exists
+         execute(testCase)
+       }
+    }
+
+    private val contexts: MutableMap<String, MicronautKotestContext> = mutableMapOf()
+
+    override suspend fun beforeSpec(spec: Spec) {
+        contexts[spec.javaClass.name]?.beforeSpec(spec)
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        contexts[spec.javaClass.name]?.afterSpec(spec)
+    }
+
+    override suspend fun beforeTest(testCase: TestCase) {
+        contexts[testCase.spec.javaClass.name]?.beforeTest(testCase)
+    }
+
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+        contexts[testCase.spec.javaClass.name]?.afterTest(testCase)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
+        // we only instantiate via spring if there's actually parameters in the constructor
+        // otherwise there's nothing to inject there
+        val constructor = clazz.primaryConstructor
+        val testClass: Class<Any> = clazz.java as Class<Any>
+        val micronautTest = AnnotationSupport.findAnnotation<MicronautTest>(testClass, MicronautTest::class.java).orElse(null)
+
+        return if (micronautTest == null) {
+            null
+        } else {
+            val createBean = constructor != null && constructor.parameters.isNotEmpty()
+            val context = MicronautKotestContext(testClass, micronautTest, createBean)
+            contexts[testClass.name] = context
+            if (createBean) {
+                context.bean
+            } else {
+                null
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> Spec.getMock(obj: T): T {
+        return if (obj is InterceptedProxy<*>) {
+            obj.interceptedTarget() as T
+        } else {
+            obj
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/test-kotest/src/test/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension
+
+object ProjectConfig : AbstractProjectConfig() {
+    override fun listeners() = listOf(MicronautKotestExtension)
+    override fun extensions() = listOf(MicronautKotestExtension)
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ApplicationRunAnotherTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ApplicationRunAnotherTest.kt
@@ -1,0 +1,62 @@
+package io.micronaut.test.kotest;
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@MicronautTest
+class ApplicationRunAnotherTest(
+        @Client("/") private val client: RxHttpClient,
+        private val testService: TestService): BehaviorSpec({
+
+    val specName = javaClass.simpleName
+
+    given("testPingServer") {
+        `when`("the mock is setup") {
+            val mock = getMock(testService)
+
+            every { mock.doStuff() } returns "mocked by $specName"
+
+            val response = client.toBlocking().retrieve(
+                    HttpRequest.GET<String>("/test"), String::class.java)
+
+            then("the response comes from the mock") {
+                response shouldBe "mocked by ApplicationRunAnotherTest"
+                verify {
+                    mock.doStuff()
+                }
+            }
+        }
+
+        `when`("the mock is changed") {
+            val mock = getMock(testService)
+
+            every { mock.doStuff() } returns "changed by $specName"
+
+            val response = client.toBlocking().retrieve(
+                    HttpRequest.GET<String>("/test"), String::class.java)
+
+            then("the mock was changed") {
+                response shouldBe "changed by ApplicationRunAnotherTest"
+                verify {
+                    mock.doStuff()
+                }
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(DefaultTestService::class)
+    fun testService(): TestService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/Book.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/Book.kt
@@ -1,0 +1,15 @@
+package io.micronaut.test.kotest
+
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+
+@Entity
+class Book {
+
+    @GeneratedValue
+    @Id
+    var id: Long? = null
+
+    var title: String? = null
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ConstructorPropertyTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/ConstructorPropertyTest.kt
@@ -1,0 +1,21 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Property(name = "foo.bar", value = "3")
+class ConstructorPropertyTest(
+        @Value("\${foo.bar}") private val value: Int,
+        @Property(name = "foo.bar") private val property: Int
+): StringSpec({
+
+  "test the values are injected"() {
+      value shouldBe 3
+      property shouldBe 3
+  }
+
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DbProperties.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DbProperties.kt
@@ -1,0 +1,13 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS, AnnotationTarget.FILE)
+@MustBeDocumented
+@PropertySource(
+        Property(name = "datasources.default.name", value = "testdb"),
+        Property(name = "jpa.default.properties.hibernate.hbm2ddl.auto", value = "update")
+)
+annotation class DbProperties

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DefaultTestService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/DefaultTestService.kt
@@ -1,0 +1,11 @@
+package io.micronaut.test.kotest
+
+import javax.inject.Singleton
+
+@Singleton
+class DefaultTestService : TestService {
+
+    override fun doStuff(): String {
+        return "original"
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/EmptyConstructorTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/EmptyConstructorTest.kt
@@ -1,0 +1,18 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import javax.inject.Inject
+
+@MicronautTest
+class EmptyConstructorTest: StringSpec() {
+
+    @Inject lateinit var mathService: MathService
+
+    init {
+        "test should be called"() {
+            mathService.compute(1) shouldBe 4
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaNoRollbackTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaNoRollbackTest.kt
@@ -1,0 +1,58 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.test.annotation.MicronautTest
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.DefaultTransactionDefinition
+import javax.persistence.EntityManager
+
+@MicronautTest(rollback = false)
+@DbProperties
+class JpaNoRollbackTest(private val entityManager: EntityManager,
+                        private val transactionManager: PlatformTransactionManager): BehaviorSpec({
+
+    given("no rollback between tests") {
+        `when`("test persist one") {
+            val book = Book()
+            book.title = "The Stand"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 1
+            }
+        }
+    }
+
+    given("a new transaction") {
+        `when`("test persist two") {
+            val book = Book()
+            book.title = "The Shining"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 2
+            }
+        }
+    }
+}) {
+
+    override fun afterSpec(spec: Spec) {
+        val tx = transactionManager.getTransaction(DefaultTransactionDefinition())
+        val criteriaBuilder = entityManager.criteriaBuilder
+        val delete = criteriaBuilder.createCriteriaDelete(Book::class.java)
+        delete.from(Book::class.java)
+        entityManager.createQuery(delete).executeUpdate()
+        transactionManager.commit(tx)
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaRollbackTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/JpaRollbackTest.kt
@@ -1,0 +1,47 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.test.annotation.MicronautTest
+import org.springframework.transaction.PlatformTransactionManager
+
+import javax.persistence.EntityManager
+
+@MicronautTest
+@DbProperties
+class JpaRollbackTest(private val entityManager: EntityManager,
+                      private val transactionManager: PlatformTransactionManager): BehaviorSpec({
+
+    given("rollback between tests") {
+        `when`("test persist one") {
+            val book = Book()
+            book.title = "The Stand"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 1
+            }
+        }
+    }
+
+    given("a new transaction") {
+        `when`("test persist two") {
+            val book = Book()
+            book.title = "The Shining"
+            entityManager.persist(book)
+
+            then("the book is persisted") {
+                entityManager.find(Book::class.java, book.id) shouldNotBe null
+
+                val query = entityManager.criteriaBuilder.createQuery(Book::class.java)
+                query.from(Book::class.java)
+                entityManager.createQuery(query).resultList.size shouldBe 1
+            }
+        }
+    }
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathCollaboratorTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathCollaboratorTest.kt
@@ -1,0 +1,48 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+@MicronautTest
+class MathCollaboratorTest(
+        private val mathService: MathService,
+        @Client("/") private val client: RxHttpClient // <2>
+): StringSpec({
+
+    "test compute num to square" {
+        val mock = getMock(mathService)
+
+        every { mock.compute(any()) } answers {
+            firstArg<Int>().toDouble().pow(2).roundToInt()
+        }
+
+        forAll(
+            row(2, 4),
+            row(3, 9)
+        ) { a: Int, b: Int ->
+            val result = client.toBlocking().retrieve("/math/compute/$a", Int::class.java) // <3>
+            result shouldBe b
+            verify { mock.compute(a) } // <4>
+        }
+
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class) // <1>
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathController.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathController.kt
@@ -1,0 +1,14 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/math")
+class MathController internal constructor(internal var mathService: MathService) {
+
+    @Get(uri = "/compute/{number}", processes = [MediaType.TEXT_PLAIN])
+    internal fun compute(number: Int): String {
+        return mathService.compute(number).toString()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathInnerService2Test.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathInnerService2Test.kt
@@ -1,0 +1,38 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+
+@MicronautTest
+class MathInnerService2Test(
+        private val mathService: MathService,
+        private val services: Array<MathService>
+): BehaviorSpec({
+
+    given("an inner class mock") {
+
+        `when`("the mock is called") {
+            val result = mathService.compute(10)
+
+            then("the mock is used") {
+                result shouldBe 50
+                mathService is MyService
+                services.size shouldBe 1
+            }
+
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    open class MyService : MathService {
+
+        override fun compute(num: Int): Int {
+            return num * 5
+        }
+    }
+}
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockService2Test.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockService2Test.kt
@@ -1,0 +1,28 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.mockk.mockk
+
+@MicronautTest
+class MathMockService2Test(
+        private val mathServices: Array<MathService>
+): BehaviorSpec({
+
+    given("an array of services") {
+        `when`("the services are injected") {
+            then("the array contains a single service") {
+                mathServices.size shouldBe 1
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockServiceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathMockServiceTest.kt
@@ -1,0 +1,41 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+@MicronautTest
+class MathMockServiceTest(
+        private val mathService: MathService // <3>
+): BehaviorSpec({
+
+    given("test compute num to square") {
+
+        `when`("the mock is provided") {
+            val mock = getMock(mathService) // <4>
+            every { mock.compute(any()) } answers {
+                firstArg<Int>().toDouble().pow(2).roundToInt()
+            }
+
+            then("the mock implementation is used") {
+                mock.compute(3) shouldBe 9
+                verify { mock.compute(3) } // <5>
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class) // <1>
+    fun mathService(): MathService {
+        return mockk() // <2>
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathService.kt
@@ -1,0 +1,7 @@
+package io.micronaut.test.kotest
+
+interface MathService {
+
+    fun compute(num: Int): Int
+}
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceImpl.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceImpl.kt
@@ -1,0 +1,11 @@
+package io.micronaut.test.kotest
+
+import javax.inject.Singleton
+
+@Singleton
+internal class MathServiceImpl : MathService {
+
+    override fun compute(num: Int): Int {
+        return num * 4
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTest.kt
@@ -1,0 +1,28 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest // <1>
+class MathServiceTest(
+        private val mathService: MathService // <2>
+): BehaviorSpec({
+
+    given("the math service") {
+
+        `when`("the service is called with 2") {
+            val result = mathService.compute(2) // <3>
+            then("the result is 8") {
+                result shouldBe 8
+            }
+        }
+
+        `when`("the service is called with 3") {
+            val result = mathService.compute(3)
+            then("the result is 12") {
+                result shouldBe 12
+            }
+        }
+    }
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTestSimilarNameTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/MathServiceTestSimilarNameTest.kt
@@ -1,0 +1,34 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.kotest.MicronautKotestExtension.getMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@MicronautTest
+class MathServiceTestSimilarNameTest(private val mathService: MathService): BehaviorSpec({
+
+    given("test similarly named test suites dont leak mocks") {
+
+        `when`("the mock is provided") {
+            val mock = getMock(mathService)
+            every { mock.compute(10) } returns 20
+
+            then("the mock is used") {
+                mock.compute(10) shouldBe 20
+                verify { mock.compute(10) }
+            }
+        }
+    }
+
+}) {
+
+    @MockBean(MathServiceImpl::class)
+    fun mathService(): MathService {
+        return mockk()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertySourceTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertySourceTest.kt
@@ -1,0 +1,23 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest(propertySources = ["myprops.properties"])
+@Property(name = "supplied.value", value = "hello")
+class PropertySourceTest(@Property(name = "foo.bar") val value: String,
+                         @Property(name = "supplied.value") val suppliedValue: String) : BehaviorSpec({
+
+    given("a property source") {
+        `when`("the value is injected") {
+            then("the correct value is injected") {
+                value shouldBe "foo"
+                suppliedValue shouldBe "hello"
+            }
+        }
+    }
+
+})
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueRequiresTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueRequiresTest.kt
@@ -1,0 +1,45 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.beInstanceOf
+import io.kotest.matchers.should
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.annotation.MicronautTest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MicronautTest(rebuildContext = true)
+@Property(name = "foo.bar", value = "stuff")
+class PropertyValueRequiresTest: AnnotationSpec() {
+
+    @Inject
+    lateinit var myService: MyService
+
+    @Test
+    fun testInitialValue() {
+        myService should beInstanceOf<MyServiceStuff>()
+    }
+
+    @Property(name = "foo.bar", value = "changed")
+    @Test
+    fun testValueChanged() {
+        myService should beInstanceOf<MyServiceChanged>()
+    }
+
+    @Test
+    fun testValueRestored() {
+        myService should beInstanceOf<MyServiceStuff>()
+    }
+}
+
+interface MyService
+
+@Singleton
+@Requires(property = "foo.bar", value = "stuff")
+open class MyServiceStuff : MyService
+
+
+@Singleton
+@Requires(property = "foo.bar", value = "changed")
+open class MyServiceChanged : MyService

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/PropertyValueTest.kt
@@ -1,0 +1,31 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Property(name = "foo.bar", value = "stuff")
+class PropertyValueTest: AnnotationSpec() {
+
+    @Value("\${foo.bar}")
+    lateinit var value: String
+
+    @Test
+    fun testInitialValue() {
+        value shouldBe "stuff"
+    }
+
+    @Property(name = "foo.bar", value = "changed")
+    @Test
+    fun testValueChanged() {
+        value shouldBe "changed"
+    }
+
+    @Test
+    fun testValueRestored() {
+        value shouldBe "stuff"
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/RequiresTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/RequiresTest.kt
@@ -1,0 +1,16 @@
+package io.micronaut.test.kotest
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.BehaviorSpec
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+@Requires(property = "does.not.exist")
+class RequiresTest: BehaviorSpec({
+
+    given("a test with requires") {
+        fail("Should never be executed")
+    }
+
+})

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/SimpleTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/SimpleTest.kt
@@ -1,0 +1,13 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SimpleTest: StringSpec() {
+
+    init {
+        "test should be called"() {
+            1 shouldBe 1
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestController.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestController.kt
@@ -1,0 +1,13 @@
+package io.micronaut.test.kotest
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/test")
+class TestController constructor(private val testService: TestService) {
+
+    @Get
+    fun index(): String {
+        return testService.doStuff()
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestPropertiesProviderTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestPropertiesProviderTest.kt
@@ -1,0 +1,26 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import javax.inject.Inject
+
+@MicronautTest
+class TestPropertiesProviderTest: StringSpec(), TestPropertyProvider {
+
+    override fun getProperties(): MutableMap<String, String> {
+        return mutableMapOf("foo.bar" to "3")
+    }
+
+    @set:Inject
+    @setparam:Property(name = "foo.bar")
+    var property: Int = 0
+
+    init {
+        "test the property was injected"() {
+            property shouldBe 3
+        }
+    }
+}

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestService.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TestService.kt
@@ -1,0 +1,6 @@
+package io.micronaut.test.kotest
+
+interface TestService {
+
+    fun doStuff(): String
+}

--- a/test-kotest/src/test/resources/io/micronaut/test/kotest/myprops.properties
+++ b/test-kotest/src/test/resources/io/micronaut/test/kotest/myprops.properties
@@ -1,0 +1,1 @@
+foo.bar=foo

--- a/test-kotest/src/test/resources/logback.xml
+++ b/test-kotest/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!--<logger name="io.micronaut.context" level="trace" />-->
+</configuration>


### PR DESCRIPTION
Since version 4, kotlintest has been renamed to kotest, and also has a few other breaking changes (mostly package restructuring). See https://github.com/kotest/kotest

In order to be able to use this new version with Micronaut, I created a copy of the `test-kotlintest` package, and reworked it to depend on and work with kotest -- also including all tests found in `test-kotlintest`. 

On thing I do not completely understand: I had to make this project depending on test-junit5, otherwise all tests failed because `MicronautJunit5Extension` is not found. It's unclear why this is not a problem for `test-kotlintest`.