### PR TITLE
Add support for TestExecutionListener

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/context/TestContext.java
+++ b/test-core/src/main/java/io/micronaut/test/context/TestContext.java
@@ -1,0 +1,77 @@
+package io.micronaut.test.context;
+
+import io.micronaut.context.ApplicationContext;
+import java.lang.reflect.AnnotatedElement;
+
+/**
+ * Test context used by {@link TestExecutionListener}s.
+ *
+ * @author bidorffOL
+ * @since 1.2
+ */
+public class TestContext {
+
+  private final ApplicationContext applicationContext;
+  private final Class<?> testClass;
+  private final AnnotatedElement testMethod;
+  private final Throwable testException;
+  private final Object testInstance;
+
+  /**
+   * @param applicationContext The application context
+   * @param testClass The test class
+   * @param testMethod The test method
+   * @param testInstance The test instance
+   * @param testException The exception thrown by the test execution
+   */
+  public TestContext(
+      final ApplicationContext applicationContext,
+      final Class<?> testClass,
+      final AnnotatedElement testMethod,
+      final Object testInstance,
+      final Throwable testException) {
+
+    this.applicationContext = applicationContext;
+    this.testClass = testClass;
+    this.testException = testException;
+    this.testInstance = testInstance;
+    this.testMethod = testMethod;
+
+  }
+
+  /**
+   * @return The application context
+   */
+  public ApplicationContext getApplicationContext() {
+    return applicationContext;
+  }
+
+  /**
+   * @return The test class
+   */
+  public Class<?> getTestClass() {
+    return testClass;
+  }
+
+  /**
+   * @return The test instance
+   */
+  public Throwable getTestException() {
+    return testException;
+  }
+
+  /**
+   * @return The test method
+   */
+  public AnnotatedElement getTestMethod() {
+    return testMethod;
+  }
+
+  /**
+   * @return The exception thrown by the test execution
+   */
+  public Object getTestInstance() {
+    return testInstance;
+  }
+
+}

--- a/test-core/src/main/java/io/micronaut/test/context/TestExecutionListener.java
+++ b/test-core/src/main/java/io/micronaut/test/context/TestExecutionListener.java
@@ -1,0 +1,72 @@
+package io.micronaut.test.context;
+
+/**
+ * Test execution listener.
+ *
+ * @author bidorffOL
+ * @since 1.2
+ */
+public interface TestExecutionListener {
+
+  /**
+   * Executed before all of the tests of a class are executed.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void beforeTestClass(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed before a test method is executed (a test method may contain multiple iterations).
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void beforeTestMethod(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed before a single test iteration is executed.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void beforeTestExecution(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed after a single test iteration has been executed .
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void afterTestExecution(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed after a test method has been executed (a test method may contain multiple
+   * iterations).
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void afterTestMethod(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed after all of the tests of a class have bean executed.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   */
+  default void afterTestClass(TestContext testContext) throws Exception {
+
+  }
+
+}

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -35,8 +35,9 @@ import io.micronaut.runtime.context.scope.refresh.RefreshScope;
 import io.micronaut.test.annotation.AnnotationUtils;
 import io.micronaut.test.annotation.MicronautTest;
 import io.micronaut.test.condition.TestActiveCondition;
+import io.micronaut.test.context.TestContext;
+import io.micronaut.test.context.TestExecutionListener;
 import io.micronaut.test.support.TestPropertyProvider;
-import io.micronaut.test.transaction.TestTransactionInterceptor;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -51,7 +52,9 @@ import java.util.*;
  * @since 1.0
  * @param <C> The extension context
  */
-public abstract class AbstractMicronautExtension<C> implements TestTransactionInterceptor  {
+public abstract class AbstractMicronautExtension<C> implements TestExecutionListener {
+    public static final String TEST_ROLLBACK = "micronaut.test.rollback";
+    public static final String TEST_TRANSACTIONAL = "micronaut.test.transactional";
     public static final String DISABLED_MESSAGE = "Test is not bean. Either the test does not satisfy requirements defined by @Requires or annotation processing is not enabled. If the latter ensure annotation processing is enabled in your IDE.";
     public static final String MISCONFIGURED_MESSAGE = "@MicronautTest used on test but no bean definition for the test present. This error indicates a misconfigured build or IDE. Please add the 'micronaut-inject-java' annotation processor to your test processor path (for Java this is the testAnnotationProcessor scope, for Kotlin kaptTest and for Groovy testCompile). See the documentation for reference: https://micronaut-projects.github.io/micronaut-test/latest/guide/";
     private static Map<String, PropertySourceLoader> loaderMap;
@@ -61,41 +64,61 @@ public abstract class AbstractMicronautExtension<C> implements TestTransactionIn
     protected BeanDefinition<?> specDefinition;
     protected Map<String, Object> testProperties = new LinkedHashMap<>();
     protected Map<String, Object> oldValues = new LinkedHashMap<>();
-    private boolean rollback = true;
-    private boolean transactional = true;
     private MicronautTest testAnnotation;
     private ApplicationContextBuilder builder = ApplicationContext.build();
 
+    /** {@inheritDoc} */
     @Override
-    public void begin() {
-        if (transactional && applicationContext != null) {
-            Collection<TestTransactionInterceptor> interceptors = applicationContext.getBeansOfType(TestTransactionInterceptor.class);
-            for (TestTransactionInterceptor interceptor : interceptors) {
-                interceptor.begin();
-            }
-        }
+    public void beforeTestExecution(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::beforeTestExecution, testContext);
     }
 
+    /** {@inheritDoc} */
     @Override
-    public void commit() {
-        if (transactional && applicationContext != null && !rollback) {
-            Collection<TestTransactionInterceptor> interceptors = applicationContext.getBeansOfType(TestTransactionInterceptor.class);
-            for (TestTransactionInterceptor interceptor : interceptors) {
-                interceptor.commit();
-            }
-        }
-
+    public void afterTestExecution(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::afterTestExecution, testContext);
     }
 
+    /** {@inheritDoc} */
     @Override
-    public void rollback() {
-        if (transactional && applicationContext != null && rollback) {
-            Collection<TestTransactionInterceptor> interceptors = applicationContext.getBeansOfType(TestTransactionInterceptor.class);
-            for (TestTransactionInterceptor interceptor : interceptors) {
-                interceptor.rollback();
-            }
-        }
+    public void beforeTestClass(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::beforeTestClass, testContext);
+    }
 
+    /** {@inheritDoc} */
+    @Override
+    public void afterTestClass(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::afterTestClass, testContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void beforeTestMethod(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::beforeTestMethod, testContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::afterTestMethod, testContext);
+    }
+
+    /**
+     * Actually fires the execution listener.
+     *
+     * @param callback the execution listener callback
+     * @param testContext the test context
+     * @throws Exception allows any exception to propagate
+     */
+    private void fireListeners(TestListenerCallback callback, TestContext testContext) throws Exception {
+        if (applicationContext != null) {
+
+            Collection<TestExecutionListener> listeners = applicationContext.getBeansOfType(TestExecutionListener.class);
+            for (TestExecutionListener listener : listeners) {
+                callback.apply(listener, testContext);
+            }
+
+        }
     }
 
     /**
@@ -112,8 +135,6 @@ public abstract class AbstractMicronautExtension<C> implements TestTransactionIn
                 this.builder = InstantiationUtils.instantiate(cb[0]);
             }
             this.testAnnotation = testAnnotation;
-            this.rollback = testAnnotation.rollback();
-            this.transactional = testAnnotation.transactional();
 
             final Package aPackage = testClass.getPackage();
             builder.packages(aPackage.getName());
@@ -164,6 +185,8 @@ public abstract class AbstractMicronautExtension<C> implements TestTransactionIn
             }
             testProperties.put(TestActiveCondition.ACTIVE_SPEC_NAME, aPackage.getName() + "." + testClass.getSimpleName());
             testProperties.put(TestActiveCondition.ACTIVE_SPEC_CLAZZ, testClass);
+            testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotation.rollback()));
+            testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotation.transactional()));
             final Class<?> application = testAnnotation.application();
             if (application != void.class) {
                 builder.mainClass(application);
@@ -263,8 +286,9 @@ public abstract class AbstractMicronautExtension<C> implements TestTransactionIn
      * Executed after each test completes.
      *
      * @param context The context
+     * @throws Exception allows any exception to propagate
      */
-    public void afterEach(C context) {
+    public void afterEach(C context) throws Exception {
         if (refreshScope != null) {
             if (!oldValues.isEmpty()) {
                 testProperties.putAll(oldValues);
@@ -314,4 +338,15 @@ public abstract class AbstractMicronautExtension<C> implements TestTransactionIn
         }
         return loaderMap;
     }
+
+    /**
+     * Fires events to the {@link TestExecutionListener}s.
+     */
+    @FunctionalInterface
+    private interface TestListenerCallback {
+
+        void apply(TestExecutionListener listener, TestContext context) throws Exception;
+
+    }
+
 }

--- a/test-core/src/main/java/io/micronaut/test/transaction/TestTransactionInterceptor.java
+++ b/test-core/src/main/java/io/micronaut/test/transaction/TestTransactionInterceptor.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Indexed;
  * @author graemerocher
  * @since 1.0
  */
+@Deprecated
 @Indexed(TestTransactionInterceptor.class)
 public interface TestTransactionInterceptor {
 

--- a/test-core/src/main/java/io/micronaut/test/transaction/TestTransactionInterceptorListener.java
+++ b/test-core/src/main/java/io/micronaut/test/transaction/TestTransactionInterceptorListener.java
@@ -1,0 +1,51 @@
+package io.micronaut.test.transaction;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.test.context.TestContext;
+import io.micronaut.test.context.TestExecutionListener;
+import io.micronaut.test.extensions.AbstractMicronautExtension;
+
+/**
+ * Test execution listener for retro*compatibility with legacy {@link TestTransactionInterceptor}.
+ *
+ * @author bidorffOL
+ * @since 1.2
+ */
+@EachBean(TestTransactionInterceptor.class)
+@Requires(property = AbstractMicronautExtension.TEST_TRANSACTIONAL, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+public class TestTransactionInterceptorListener implements TestExecutionListener {
+
+  private final TestTransactionInterceptor interceptor;
+  private final boolean rollback;
+
+  /**
+   * @param interceptor the interceptor
+   * @param rollback {@code true} if the transaction should be rollback
+   */
+  public TestTransactionInterceptorListener(
+      TestTransactionInterceptor interceptor,
+      @Property(name = AbstractMicronautExtension.TEST_ROLLBACK) boolean rollback) {
+
+    this.interceptor = interceptor;
+    this.rollback = rollback;
+
+  }
+
+  @Override
+  public void afterTestExecution(TestContext testContext) {
+    if (rollback) {
+      interceptor.rollback();
+    } else {
+      interceptor.commit();
+    }
+  }
+
+  @Override
+  public void beforeTestExecution(TestContext testContext) {
+    interceptor.begin();
+  }
+
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/NonTransactionalTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/NonTransactionalTest.java
@@ -1,0 +1,22 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.transaction.spring.SpringTransactionTestExecutionListener;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest(transactional = false)
+@DbProperties
+class NonTransactionalTest {
+
+  @Inject
+  ApplicationContext applicationContext;
+
+  @Test
+  void testSpringTransactionListenerMissing() {
+    Assertions.assertFalse(applicationContext.containsBean(SpringTransactionTestExecutionListener.class));
+  }
+
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalTest.java
@@ -1,0 +1,22 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.transaction.spring.SpringTransactionTestExecutionListener;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest(transactional = true)
+@DbProperties
+class TransactionalTest {
+
+  @Inject
+  ApplicationContext applicationContext;
+
+  @Test
+  void testSpringTransactionListenerMissing() {
+    Assertions.assertTrue(applicationContext.containsBean(SpringTransactionTestExecutionListener.class));
+  }
+
+}

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestContext.kt
@@ -17,8 +17,10 @@ package io.micronaut.test.extensions.kotest
 
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.context.TestContext
 import io.micronaut.test.extensions.AbstractMicronautExtension
 import io.micronaut.test.support.TestPropertyProvider
 import kotlin.reflect.full.memberFunctions
@@ -52,9 +54,11 @@ class MicronautKotestContext(private val testClass: Class<Any>,
             beforeClass(spec, testClass, micronautTest)
             applicationContext.inject(spec)
         }
+        beforeTestClass(buildContext(spec))
     }
 
     fun afterSpecClass(spec: Spec) {
+        afterTestClass(buildContext(spec))
         afterClass(spec)
     }
 
@@ -66,14 +70,29 @@ class MicronautKotestContext(private val testClass: Class<Any>,
             propertyAnnotations = filter.first().annotations.filter { it is Property } as? List<Property>
         }
         beforeEach(testCase.spec, testCase.spec, testCase.test.javaClass, propertyAnnotations)
-        begin()
+        beforeTestMethod(buildContext(testCase, null))
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun afterTest(testCase: TestCase) {
-        commit()
-        rollback()
+    fun afterTest(testCase: TestCase, result: TestResult) {
+        afterTestMethod(buildContext(testCase, result))
+    }
+
+    fun beforeInvocation(testCase: TestCase) {
+        beforeTestExecution(buildContext(testCase, null))
+    }
+
+    fun afterInvocation(testCase: TestCase) {
+        afterTestExecution(buildContext(testCase, null))
     }
 
     fun getSpecDefinition() = specDefinition
+
+    fun buildContext(spec: Spec): TestContext {
+        return TestContext(applicationContext, spec.javaClass, null, spec, null)
+    }
+
+    fun buildContext(testCase: TestCase, result: TestResult?): TestContext {
+        return TestContext(applicationContext, testCase.spec.javaClass, testCase.test.javaClass, testCase.spec, result?.error)
+    }
+
 }

--- a/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
+++ b/test-kotest/src/main/kotlin/io/micronaut/test/extensions/kotest/MicronautKotestExtension.kt
@@ -57,10 +57,16 @@ object MicronautKotestExtension: TestListener, ConstructorExtension, TestCaseExt
     }
 
     override suspend fun afterTest(testCase: TestCase, result: TestResult) {
-        contexts[testCase.spec.javaClass.name]?.afterTest(testCase)
+        contexts[testCase.spec.javaClass.name]?.afterTest(testCase, result)
     }
-    
-    
+
+    override suspend fun beforeInvocation(testCase: TestCase, iteration: Int) {
+        contexts[testCase.spec.javaClass.name]?.beforeInvocation(testCase)
+    }
+
+    override suspend fun afterInvocation(testCase: TestCase, iteration: Int) {
+        contexts[testCase.spec.javaClass.name]?.afterInvocation(testCase)
+    }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/NonTransactionalTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/NonTransactionalTest.kt
@@ -1,0 +1,23 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.transaction.spring.SpringTransactionTestExecutionListener
+
+@MicronautTest(transactional = false)
+@DbProperties
+class NonTransactionalTest(
+        private val applicationContext: ApplicationContext) : BehaviorSpec({
+
+    given("a test") {
+        `when`("the test is not transactional") {
+            then("the SpringTransactionTestExecutionListener does not exist") {
+                applicationContext.containsBean(SpringTransactionTestExecutionListener::class.java) shouldBe false
+            }
+        }
+    }
+
+})
+

--- a/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TransactionalTest.kt
+++ b/test-kotest/src/test/kotlin/io/micronaut/test/kotest/TransactionalTest.kt
@@ -1,0 +1,23 @@
+package io.micronaut.test.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.transaction.spring.SpringTransactionTestExecutionListener
+
+@MicronautTest(transactional = true)
+@DbProperties
+class TransactionalTest(
+        private val applicationContext: ApplicationContext) : BehaviorSpec({
+
+    given("a test") {
+        `when`("the test is transactional") {
+            then("the SpringTransactionTestExecutionListener does exist") {
+                applicationContext.containsBean(SpringTransactionTestExecutionListener::class.java) shouldBe true
+            }
+        }
+    }
+
+})
+

--- a/test-kotlintest/src/main/kotlin/io/micronaut/test/extensions/kotlintest/MicronautKotlinTestExtension.kt
+++ b/test-kotlintest/src/main/kotlin/io/micronaut/test/extensions/kotlintest/MicronautKotlinTestExtension.kt
@@ -59,10 +59,12 @@ object MicronautKotlinTestExtension: TestListener, ConstructorExtension, TestCas
 
     override fun beforeTest(testCase: TestCase) {
         contexts[testCase.spec.javaClass.name]?.beforeTest(testCase)
+        contexts[testCase.spec.javaClass.name]?.beforeInvocation(testCase)
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
-        contexts[testCase.spec.javaClass.name]?.afterTest(testCase)
+        contexts[testCase.spec.javaClass.name]?.afterInvocation(testCase)
+        contexts[testCase.spec.javaClass.name]?.afterTest(testCase, result)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/GormTransactionalRollbackSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/GormTransactionalRollbackSpec.groovy
@@ -6,7 +6,7 @@ import io.micronaut.core.util.StringUtils
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.test.annotation.MicronautTest
 import io.micronaut.test.spock.entities.Book
-import io.micronaut.test.transaction.spring.SpringTestTransactionInterceptor
+import io.micronaut.test.transaction.spring.SpringTransactionTestExecutionListener
 import spock.lang.Specification
 import spock.lang.Stepwise
 
@@ -29,9 +29,9 @@ class GormTransactionalRollbackSpec extends Specification {
     @Inject
     ApplicationContext applicationContext
 
-    void "bean SpringTestTransactionInterceptor exists"() {
+    void "bean SpringTransactionTestExecutionListener exists"() {
         expect:
-        applicationContext.containsBean(SpringTestTransactionInterceptor)
+        applicationContext.containsBean(SpringTransactionTestExecutionListener)
     }
 
     void "save book"() {


### PR DESCRIPTION
Resolve #163 

This is a first attempt to deprecate `TestTransactionInterceptor ` and use a more complete `TestExecutionListener` instead. I lack experience with both Kotest & Spock, so I'm really looking for feedback on this PR.