### PR TITLE
Do not include `spockVersion` in PRs send to core

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ githubBranch=master
 githubCoreBranch=master
 bomProperty=micronautTestVersion
 # If needed, set additional properties
-bomProperties=junitVersion,spockVersion,kotlintestVersion,kotestVersion
+bomProperties=junitVersion,kotlintestVersion,kotestVersion
 kotlintestVersion=3.4.2
 kotestVersion=4.0.3
 developers=Graeme Rocher


### PR DESCRIPTION
This change can be reverted once we upgrade Micronaut Test to Micronaut 2.0