### PR TITLE
Bump kotest version to 4.1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ bomProperty=micronautTestVersion
 # If needed, set additional properties
 bomProperties=junitVersion,kotlintestVersion,kotestVersion
 kotlintestVersion=3.4.2
-kotestVersion=4.0.3
+kotestVersion=4.1.3
 developers=Graeme Rocher
 # Not really needed for this project, but anyway
 kafkaVersion="Unknown"

--- a/src/main/docs/guide/kotest.adoc
+++ b/src/main/docs/guide/kotest.adoc
@@ -9,7 +9,7 @@ dependencies {
     kaptTest "io.micronaut:micronaut-inject-java"
     testImplementation "io.micronaut.test:micronaut-test-kotest:{version}"
     testImplementation "io.mockk:mockk:1.9.3"
-    testImplementation "io.kotest:kotest-runner-junit5-jvm:4.0.3"
+    testImplementation "io.kotest:kotest-runner-junit5-jvm:4.1.3"
 }
 
 // use JUnit 5 platform
@@ -38,7 +38,7 @@ Or for Maven:
 <dependency>
     <groupId>io.kotest</groupId>
     <artifactId>kotest-runner-junit5-jvm</artifactId>
-    <version>4.0.3</version>
+    <version>4.1.3</version>
     <scope>test</scope>
 </dependency>
 ----


### PR DESCRIPTION
Hey there, I would like to bump kotest's version to 4.1.3, because the testcontainers extension of kotest is supported only from version 4.1.*