### PR TITLE
build: expose kotest-assertions-core-jvm dependency as Gradle api scope

### DIFF
--- a/test-kotest/build.gradle
+++ b/test-kotest/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation "io.micronaut:micronaut-inject:$micronautVersion"
     api "io.micronaut:micronaut-runtime:$micronautVersion"    
     api "io.kotest:kotest-runner-junit5-jvm:$kotestVersion"
+    api "io.kotest:kotest-assertions-core-jvm:$kotestVersion"
 
     implementation project(":test-junit5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
@@ -23,7 +24,7 @@ dependencies {
     testRuntimeOnly "io.micronaut.configuration:micronaut-jdbc-tomcat:$micronautSqlVersion"
     testRuntimeOnly "com.h2database:h2:1.4.200"
     
-    testImplementation "io.kotest:kotest-assertions-core-jvm:$kotestVersion"
+
 }
 
 test {


### PR DESCRIPTION
I think it is probably better to expose `kotest-assertions-core-jvm` as an api dependency. Users will 99% need this dependency in their tests. It is the one which contains things such as: 

```
import io.kotest.matchers.string.shouldContain
import io.kotest.matchers.booleans.shouldBeTrue
import io.kotest.matchers.booleans.shouldBeFalse
import io.kotest.matchers.nulls.shouldNotBeNull
import io.kotest.matchers.shouldBe
```

And since we are exposing `kotest-runner-junit5-jvm` it will ensure the `kotest-assertions-core-jvm` uses the same kotest version. 