### PR TITLE
Allow Micronaut Test to run against an external server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-projectVersion=2.1.2.BUILD-SNAPSHOT
+projectVersion=2.2.0.BUILD-SNAPSHOT
 micronautDocsVersion=1.0.23
-micronautVersion=2.0.0
+micronautVersion=2.1.2
 micronautBuildVersion=1.1.5
 
 spockVersion=2.0-M3-groovy-3.0

--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
     compileOnly "io.micronaut.spring:micronaut-spring:2.1.1"
-    compileOnly "io.micronaut:micronaut-http-server:$micronautVersion"
     compileOnly("org.spockframework:spock-core:$spockVersion") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
-    compileOnly "io.micronaut:micronaut-spring:2.0.1"
+    compileOnly "io.micronaut.spring:micronaut-spring:2.1.1"
+    compileOnly "io.micronaut:micronaut-http-server:$micronautVersion"
     compileOnly("org.spockframework:spock-core:$spockVersion") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/test-core/src/main/java/io/micronaut/test/support/server/TestEmbeddedServer.java
+++ b/test-core/src/main/java/io/micronaut/test/support/server/TestEmbeddedServer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.support.server;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.socket.SocketUtils;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+
+import javax.inject.Singleton;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * An {@link EmbeddedServer} implementation that can be enabled by setting {@code micronaut.test.server.url} to run tests against and existing running server.
+ *
+ * @author graemerocher
+ * @since 2.2.0
+ */
+@Singleton
+@Primary
+@Requires(property = TestEmbeddedServer.PROPERTY)
+public class TestEmbeddedServer implements EmbeddedServer {
+    public static final String PROPERTY = "micronaut.test.server.url";
+    private final ApplicationContext applicationContext;
+    private final URL url;
+    private final ApplicationConfiguration applicationConfiguration;
+
+    /**
+     * Default constructor.
+     * @param url The server URL
+     * @param applicationConfiguration The application configuration
+     * @param applicationContext The application context
+     */
+    @Internal
+    protected TestEmbeddedServer(
+            @Property(name = PROPERTY) URL url,
+            ApplicationConfiguration applicationConfiguration,
+            ApplicationContext applicationContext) {
+        this.url = url;
+        this.applicationConfiguration = applicationConfiguration;
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public int getPort() {
+        return getURL().getPort();
+    }
+
+    @Override
+    public String getHost() {
+        return getURL().getHost();
+    }
+
+    @Override
+    public String getScheme() {
+        return getURL().getProtocol();
+    }
+
+    @Override
+    public URL getURL() {
+        return url;
+    }
+
+    @Override
+    public URI getURI() {
+        try {
+            return getURL().toURI();
+        } catch (URISyntaxException e) {
+            throw new ConfigurationException("Invalid Server URL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public ApplicationConfiguration getApplicationConfiguration() {
+        return applicationConfiguration;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return !SocketUtils.isTcpPortAvailable(getPort()) && applicationContext.isRunning();
+    }
+
+    @Override
+    public boolean isServer() {
+        return true;
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/server/ExternalServerTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/server/ExternalServerTest.java
@@ -1,0 +1,67 @@
+package io.micronaut.test.junit5.server;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.test.support.server.TestEmbeddedServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ExternalServerTest implements TestPropertyProvider {
+
+    static EmbeddedServer EXTERNAL_SERVER = ApplicationContext.run(
+            EmbeddedServer.class,
+                Collections.singletonMap("micronaut.server.port", -1)
+            );
+    static final int PORT = EXTERNAL_SERVER.getPort();
+
+    @Inject
+    @Client("/")
+    RxHttpClient client;
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @AfterAll
+    static void shutdown() {
+        EXTERNAL_SERVER.stop();
+    }
+
+    @Test
+    void testServerAvailable() {
+        HttpResponse<String> response = client.exchange("/math/compute/10", String.class).blockingFirst();
+
+        assertTrue(
+            embeddedServer instanceof TestEmbeddedServer
+        );
+        assertEquals(
+                embeddedServer.getPort(),
+                PORT
+        );
+        assertEquals(
+                HttpStatus.OK,
+                response.status()
+        );
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap(
+                TestEmbeddedServer.PROPERTY, EXTERNAL_SERVER.getURL().toString()
+        );
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/server/ExternalServerTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/server/ExternalServerTest.java
@@ -48,6 +48,9 @@ public class ExternalServerTest implements TestPropertyProvider {
         assertTrue(
             embeddedServer instanceof TestEmbeddedServer
         );
+        assertTrue(
+                embeddedServer.isRunning()
+        );
         assertEquals(
                 embeddedServer.getPort(),
                 PORT


### PR DESCRIPTION
This PR allows Micronaut test to use an embedded server that is already running, for example if the build tool (maven or gradle) were to start the server another way prior to test execution