### PR TITLE
Allow micronaut test to manage execution of external process server

### DIFF
--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
     compileOnly "io.micronaut.spring:micronaut-spring:2.1.1"
+    compileOnly "io.micronaut:micronaut-http-server:$micronautVersion"
     compileOnly("org.spockframework:spock-core:$spockVersion") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/test-core/src/main/java/io/micronaut/test/annotation/MicronautTestValue.java
+++ b/test-core/src/main/java/io/micronaut/test/annotation/MicronautTestValue.java
@@ -51,6 +51,7 @@ public class MicronautTestValue {
      * @param rebuildContext  true if the application context should be rebuilt for each test method
      * @param contextBuilder  The builder
      * @param transactionMode The transaction mode
+     * @param startApplication Whether the start the app
      */
     @Creator
     public MicronautTestValue(Class<?> application, String[] environments, String[] packages, String[] propertySources,

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -58,6 +58,10 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     public static final String TEST_TRANSACTION_MODE = "micronaut.test.transaction-mode";
     public static final String DISABLED_MESSAGE = "Test is not bean. Either the test does not satisfy requirements defined by @Requires or annotation processing is not enabled. If the latter ensure annotation processing is enabled in your IDE.";
     public static final String MISCONFIGURED_MESSAGE = "@MicronautTest used on test but no bean definition for the test present. This error indicates a misconfigured build or IDE. Please add the 'micronaut-inject-java' annotation processor to your test processor path (for Java this is the testAnnotationProcessor scope, for Kotlin kaptTest and for Groovy testCompile). See the documentation for reference: https://micronaut-projects.github.io/micronaut-test/latest/guide/";
+    /**
+     * The name of the property source that contains test properties.
+     */
+    public static final String TEST_PROPERTY_SOURCE = "test-properties";
     private static Map<String, PropertySourceLoader> loaderMap;
     protected ApplicationContext applicationContext;
     protected EmbeddedApplication embeddedApplication;
@@ -221,7 +225,11 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
             builder.packages(testAnnotationValue.packages())
                    .environments(environments);
 
-            builder.propertySources(io.micronaut.context.env.PropertySource.of(testProperties));
+            PropertySource testPropertySource = PropertySource.of(
+                    TEST_PROPERTY_SOURCE,
+                    testProperties
+            );
+            builder.propertySources(testPropertySource);
             this.applicationContext = builder.build();
             startApplicationContext();
             specDefinition = applicationContext.findBeanDefinition(testClass).orElse(null);

--- a/test-core/src/main/java/io/micronaut/test/support/server/TestEmbeddedServer.java
+++ b/test-core/src/main/java/io/micronaut/test/support/server/TestEmbeddedServer.java
@@ -39,6 +39,7 @@ import java.net.URL;
 @Singleton
 @Primary
 @Requires(property = TestEmbeddedServer.PROPERTY)
+@Requires(missingProperty = TestExecutableEmbeddedServer.PROPERTY)
 public class TestEmbeddedServer implements EmbeddedServer {
     public static final String PROPERTY = "micronaut.test.server.url";
     private final ApplicationContext applicationContext;

--- a/test-core/src/main/java/io/micronaut/test/support/server/TestExecutableEmbeddedServer.java
+++ b/test-core/src/main/java/io/micronaut/test/support/server/TestExecutableEmbeddedServer.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.support.server;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.socket.SocketUtils;
+import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.http.server.exceptions.ServerStartupException;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.AbstractMicronautExtension;
+
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static io.micronaut.core.io.socket.SocketUtils.findAvailableTcpPort;
+
+/**
+ * An {@link EmbeddedServer} implementation that runs an external executable JAR or native.
+ *
+ * @author graemerocher
+ * @since 2.2.1
+ */
+@Primary
+@Requires(property = TestExecutableEmbeddedServer.PROPERTY)
+@Requires(beans = HttpServerConfiguration.class)
+@Singleton
+public class TestExecutableEmbeddedServer implements EmbeddedServer {
+    public static final String PROPERTY = "micronaut.test.server.executable";
+
+    private final String executable;
+    private final ApplicationContext applicationContext;
+    private final HttpServerConfiguration httpServerConfiguration;
+    private final Environment environment;
+
+    private int port;
+    private Process process;
+
+    /**
+     * Default constructor.
+     * @param executable The executable to run
+     * @param applicationContext The context
+     * @param httpServerConfiguration The server configuration
+     */
+    @Internal
+    protected TestExecutableEmbeddedServer(
+            @Property(name = PROPERTY)
+            String executable,
+            ApplicationContext applicationContext,
+            HttpServerConfiguration httpServerConfiguration) {
+        this.executable = executable;
+        if (!new File(executable).exists()) {
+            throw new ConfigurationException("No executable server exists at path: " + executable);
+        }
+        this.environment = applicationContext.getEnvironment();
+        this.applicationContext = applicationContext;
+        this.httpServerConfiguration = httpServerConfiguration;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public String getHost() {
+        return "localhost";
+    }
+
+    @Override
+    public String getScheme() {
+        return "http";
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return getURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new ConfigurationException("Invalid Configured Server URL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public URI getURI() {
+        return URI.create(getScheme() + "://" + getHost() + ":" + getPort());
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public ApplicationConfiguration getApplicationConfiguration() {
+        return httpServerConfiguration.getApplicationConfiguration();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return process != null;
+    }
+
+    @Override
+    public EmbeddedServer start() {
+        if (process == null) {
+            PropertySource testPropertySource = environment.getPropertySources().stream()
+                    .filter(ps -> ps.getName().equals(AbstractMicronautExtension.TEST_PROPERTY_SOURCE))
+                    .findFirst().orElse(null);
+
+            CompletableFuture<Process> processFuture = new CompletableFuture<>();
+            Integer p = httpServerConfiguration.getPort().orElse(null);
+            int port;
+            if (p == null) {
+                if (environment.getActiveNames().contains(Environment.TEST)) {
+                    port = findAvailableTcpPort();
+                } else {
+                    port = 8080;
+                }
+            } else {
+                if (p == -1) {
+                    port = findAvailableTcpPort();
+                } else {
+                    port = p;
+                }
+            }
+            new Thread(() -> {
+                ProcessBuilder processBuilder = new ProcessBuilder();
+                List<String> commandArgs = new ArrayList<>(Arrays.asList(
+                        "-Dmicronaut.environments=test",
+                        "-Dmicronaut.server.host=localhost",
+                        "-Dmicronaut.server.port=" + port
+                ));
+
+                if (executable.endsWith(".jar")) {
+                    commandArgs.addAll(0, Arrays.asList(
+                            "java",
+                            "-jar",
+                            executable
+                    ));
+                } else {
+                    commandArgs.add(0, executable);
+                }
+
+                if (testPropertySource != null) {
+                    for (String prop : testPropertySource) {
+                        commandArgs.add("-D" + prop + "=" + testPropertySource.get(prop));
+                    }
+                }
+                processBuilder.command(commandArgs);
+                processBuilder.inheritIO();
+                try {
+                    Process start = processBuilder.start();
+                    processFuture.complete(start);
+                } catch (IOException e) {
+                    processFuture.completeExceptionally(new RuntimeException("Error starting native image server: " + e.getMessage(), e));
+                }
+            }).start();
+
+            try {
+                this.process = processFuture.get();
+                long maxWait = 10000;
+                long waiting = 0;
+                while (SocketUtils.isTcpPortAvailable(port)) {
+                    Thread.sleep(100);
+                    waiting += 100;
+                    if (waiting > maxWait) {
+                        throw new ServerStartupException("Timeout waiting for test server to start");
+                    }
+                }
+                this.port = port;
+            } catch (InterruptedException | ExecutionException e) {
+                throw new ServerStartupException(e.getMessage(), e);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public EmbeddedServer stop() {
+        if (process != null) {
+            process.destroy();
+            process = null;
+        }
+        return this;
+    }
+}

--- a/test-core/src/main/java/io/micronaut/test/support/server/TestExecutableEmbeddedServer.java
+++ b/test-core/src/main/java/io/micronaut/test/support/server/TestExecutableEmbeddedServer.java
@@ -23,7 +23,6 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.exceptions.ServerStartupException;
 import io.micronaut.runtime.ApplicationConfiguration;

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/server/ProcessServerTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/server/ProcessServerTest.java
@@ -1,0 +1,65 @@
+package io.micronaut.test.junit5.server;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.test.support.server.TestEmbeddedServer;
+import io.micronaut.test.support.server.TestExecutableEmbeddedServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Property(
+    name = TestExecutableEmbeddedServer.PROPERTY,
+    value = "src/test/apps/test-app.jar"
+)
+public class ProcessServerTest implements TestPropertyProvider {
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+
+    @Inject
+    @Client("/")
+    RxHttpClient client;
+
+    @Test
+    void testServerAvailable() {
+        HttpResponse<String> response = client.exchange("/test", String.class).blockingFirst();
+
+        assertTrue(
+                embeddedServer instanceof TestExecutableEmbeddedServer
+        );
+        assertTrue(
+                embeddedServer.isRunning()
+        );
+        assertEquals(
+                HttpStatus.OK,
+                response.status()
+        );
+        assertEquals(
+                "Result = good",
+                response.body()
+        );
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap(
+                "test.property", "good"
+        );
+    }
+}


### PR DESCRIPTION
This PR takes a slightly different approach and moves the management of the process into `micronaut-test` such that it can propagate test properties to the embedded server that is split out as a process. This approach is maybe more compatible with the Maven plugin as all the build plugins have to do is pass the location of the native image using the `micronaut.test.server.executable` system property.

