### PR TITLE
Make MicronautJunit5Extension easier to extend

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -230,6 +230,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                     testProperties
             );
             builder.propertySources(testPropertySource);
+            postProcessBuilder(builder);
             this.applicationContext = builder.build();
             startApplicationContext();
             specDefinition = applicationContext.findBeanDefinition(testClass).orElse(null);
@@ -239,6 +240,13 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
             }
             refreshScope = applicationContext.findBean(RefreshScope.class).orElse(null);
         }
+    }
+
+    /**
+     * Allows subclasses to customize the builder right before context initialization.
+     * @param builder the application context builder
+     */
+    protected void postProcessBuilder(ApplicationContextBuilder builder) {
     }
 
     /**


### PR DESCRIPTION
Helps solve #330 

This is sort of a "companion MR" to [this](https://github.com/micronaut-projects/micronaut-aws/pull/748), where I'm trying to provide a `@MicronautLambdaTest` that sets up an ApplicationContext with the right configuration (eager singletons, etc.). It basically just opens up some parts of  the logic to overriding so we can achieve maximum reuse in `MicronautLambdaJunit5Extension`.
