### PR TITLE
Add support for JUnit 5 nested test classes

### DIFF
--- a/test-junit5/src/test/java/io/micronaut/test/junit5/FirstExecutionListener.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/FirstExecutionListener.java
@@ -1,7 +1,7 @@
 package io.micronaut.test.junit5;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Order;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.test.context.TestContext;
 import io.micronaut.test.context.TestExecutionListener;
 
@@ -10,6 +10,7 @@ import javax.inject.Singleton;
 
 @Singleton
 @Order(99)
+@Requires(env = TestExecutionListenerOrderTest.ENVIRONMENT)
 public class FirstExecutionListener implements TestExecutionListener {
 
     private final Provider<SecondExecutionListener> second;

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/NestedTestClassesTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/NestedTestClassesTest.java
@@ -1,0 +1,67 @@
+
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+class NestedTestClassesTest {
+
+    private static int testCount;
+
+    @Inject
+    private Dependency outerDependency;
+
+    @AfterAll
+    static void checkTestCount() {
+        assertEquals(3, testCount);
+    }
+
+    @Test
+    void incrementTestCount() {
+        testCount++;
+    }
+
+    @Nested
+    class FirstNestedClass {
+
+        @Inject
+        private Dependency nestedDependency;
+
+        @Test
+        void incrementTestCount() {
+            testCount++;
+        }
+
+        @Test
+        void enclosingTestInstanceIsInjected() {
+            assertNotNull(outerDependency);
+        }
+
+        @Nested
+        class SecondNestedClass {
+
+            @Test
+            void incrementTestCount() {
+                testCount++;
+            }
+
+            @Test
+            void allEnclosingTestInstancesAreInjected() {
+                assertNotNull(outerDependency);
+                assertNotNull(nestedDependency);
+            }
+        }
+    }
+
+    @Singleton
+    static class Dependency {}
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/SecondExecutionListener.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/SecondExecutionListener.java
@@ -1,7 +1,7 @@
 package io.micronaut.test.junit5;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Order;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.test.context.TestContext;
 import io.micronaut.test.context.TestExecutionListener;
 
@@ -10,6 +10,7 @@ import javax.inject.Singleton;
 
 @Singleton
 @Order(100)
+@Requires(env = TestExecutionListenerOrderTest.ENVIRONMENT)
 public class SecondExecutionListener implements TestExecutionListener {
 
     private final Provider<FirstExecutionListener> first;

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TestExecutionListenerOrderTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TestExecutionListenerOrderTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest(environments = TestExecutionListenerOrderTest.ENVIRONMENT)
+public class TestExecutionListenerOrderTest {
+
+    public static final String ENVIRONMENT = "TEST_EXECUTION_LISTENER_ORDER_TEST";
+
+    @Inject
+    private FirstExecutionListener firstExecutionListener;
+    @Inject
+    private SecondExecutionListener secondExecutionListener;
+
+    @Test
+    void test() {
+        assertNotNull(firstExecutionListener);
+        assertNotNull(secondExecutionListener);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-test/issues/56.

Basic support for nested test classes is added by injecting the enclosing test instances of nested test instances.

Note: The test execution listeners that are used to verify the order of callbacks (FirstExecutionListener and SecondExecutionListener) were scoped to a specific test class (TestExecutionListenerOrderTest) since they would fail for nested test classes. This is because the before and after all callbacks of JUnit extensions are executed both for top-level and nested classes, which produces the following execution order:

1. FirstExecutionListener.beforeTestClass
2. SecondExecutionListener.beforeTestClass
3. FirstExecutionListener.beforeTestClass

In this scenario, the second FirstExecutionListener.beforeTestClass would fail since SecondExecutionListener.beforeTestClass would have executed just before.