### PR TITLE
MicronautJunit5Extension: do not tear down application context in afterAll callback of nested test classes

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -106,7 +106,9 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
         afterTestClass(buildContext(extensionContext));
-        afterClass(extensionContext);
+        if (!extensionContext.getTestClass().filter(this::isNestedTestClass).isPresent()) {
+            afterClass(extensionContext);
+        }
     }
 
     @Override
@@ -288,8 +290,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     private void injectEnclosingTestInstances(ExtensionContext extensionContext) {
         extensionContext.getTestInstances().ifPresent(testInstances -> {
-            List<Object> allInstances = testInstances.getAllInstances();
-            allInstances.stream().limit(allInstances.size() - 1).forEach(applicationContext::inject);
+            testInstances.getEnclosingInstances().forEach(applicationContext::inject);
         });
     }
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MultipleNestedTestClassesTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MultipleNestedTestClassesTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class MultipleNestedTestClassesTest {
+
+    @Nested
+    class FirstNestedClass {
+
+        @Test
+        void test() {
+        }
+    }
+
+    @Nested
+    class SecondNestedClass {
+
+        @Test
+        void test() {
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/NestedTestClassesDependencyInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/NestedTestClassesDependencyInjectionTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest
-class NestedTestClassesTest {
+class NestedTestClassesDependencyInjectionTest {
 
     private static int testCount;
 


### PR DESCRIPTION
Closes https://github.com/micronaut-projects/micronaut-test/issues/420