### PR TITLE
Fix injecting correct client with constructor arguments

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -249,7 +249,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
                                     new ParameterResolutionException("Unresolvable property specified to @Property: " + finalV1.get())
                             );
                 } else {
-                    return applicationContext.getBean(argument.getType(), resolveQualifier(argument));
+                    return applicationContext.getBean(argument, resolveQualifier(argument));
                 }
             }
         } else {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ConstructorInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ConstructorInjectionTest.java
@@ -42,5 +42,9 @@ public class ConstructorInjectionTest {
         assertNotNull(client);
 
         assertEquals("test", val);
+
+        final String response = client.toBlocking().retrieve("/test");
+
+        assertEquals("original", response);
     }
 }


### PR DESCRIPTION
Currently `@Client` and generic argument handling is broken for constructor injection. This fixes that.