### PR TITLE
fix micronaut-test for native JUnit 5 testing

### DIFF
--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension


### PR DESCRIPTION
Using `./gradlew nativeTest` currently doesn't work with JUnit 5 tests annotated with `@MicronautTest`

This fixes that.