### PR TITLE
Use the correct test instance for injecting mocks in case of nested tests

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -175,25 +175,33 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     @Override
     protected void alignMocks(ExtensionContext context, Object instance) {
-        if (specDefinition != null) {
+        if (specDefinition == null) {
+            return;
+        }
+        findSpecInstance(context).ifPresent(specInstance -> {
             for (FieldInjectionPoint injectedField : specDefinition.getInjectedFields()) {
                 final boolean isMock = applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class);
                 if (isMock) {
                     final Field field = injectedField.getField();
                     field.setAccessible(true);
                     try {
-                        final Object mock = field.get(instance);
+                        final Object mock = field.get(specInstance);
                         if (mock instanceof InterceptedProxy) {
                             InterceptedProxy ip = (InterceptedProxy) mock;
                             final Object target = ip.interceptedTarget();
-                            field.set(instance, target);
+                            field.set(specInstance, target);
                         }
                     } catch (IllegalAccessException e) {
                         // continue
                     }
                 }
             }
-        }
+        });
+    }
+
+    private Optional<Object> findSpecInstance(ExtensionContext context) {
+        return context.getTestInstances()
+            .map(testInstances -> testInstances.findInstance(specDefinition.getBeanType()));
     }
 
     @Override

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -201,7 +201,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     private Optional<Object> findSpecInstance(ExtensionContext context) {
         return context.getTestInstances()
-            .map(testInstances -> testInstances.findInstance(specDefinition.getBeanType()));
+            .flatMap(testInstances -> testInstances.findInstance(specDefinition.getBeanType()));
     }
 
     @Override

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockServiceNestedTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockServiceNestedTest.java
@@ -1,0 +1,58 @@
+
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+@MicronautTest
+@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+class MathMockServiceNestedTest {
+
+    private int number = 10;
+
+    @Inject
+    MathService mathService; // <3>
+
+    @BeforeEach
+    void setup() {
+        number = 10;
+    }
+
+    @Test
+    void mockIsAvailableOnTopLevel() {
+        when(mathService.compute(number)).thenReturn(100);
+        mathService.compute(number);
+        verify(mathService).compute(10); // <4>
+    }
+
+    @Nested
+    @DisplayName("Given number is 20")
+    class GivenNumberIsTwenty {
+        @BeforeEach
+        void setup() {
+            number = 20;
+        }
+
+        @Test
+        void mockIsAvailableOnNestedLevel() {
+            when(mathService.compute(number)).thenReturn(100);
+            mathService.compute(number);
+            verify(mathService).compute(20); // <4>
+        }
+    }
+
+    @MockBean(MathServiceImpl.class) // <1>
+    MathService mathService() {
+        return mock(MathService.class); // <2>
+    }
+
+}


### PR DESCRIPTION
If using nested tests in Junit5 injecting the mocks breaks because:

- The specDefintion reflects the root test class but
- The fields that should be injected are present on the specDefinition
- The instance object reflects the innermost test class where the fields are not present