### PR TITLE
allow mocks to be produced from fields

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/annotation/MockBean.java
+++ b/test-core/src/main/java/io/micronaut/test/annotation/MockBean.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * @since 1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 @Bean
 @Requires(condition = TestActiveCondition.class)
 @Refreshable(TestActiveCondition.ACTIVE_MOCKS)

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 @MicronautTest
 @Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
-public class MathFieldMockServiceTest {
+class MathFieldMockServiceTest {
 
     @MockBean(MathServiceImpl.class) // <1>
     MathService mock = mock(MathService.class); // <2>

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
@@ -1,0 +1,42 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+public class MathFieldMockServiceTest {
+
+    @MockBean(MathServiceImpl.class) // <1>
+    MathService mock = mock(MathService.class); // <2>
+
+    @Inject
+    MathService mathService;
+
+    @ParameterizedTest
+    @CsvSource({"2,4", "3,9"})
+    void testComputeNumToSquare(Integer num, Integer square) {
+
+        when(mathService.compute(10))
+                .then(invocation -> Long.valueOf(Math.round(Math.pow(num, 2))).intValue());
+
+        final Integer result = mathService.compute(10);
+
+        Assertions.assertEquals(
+                square,
+                result
+        );
+        verify(mathService).compute(10); // <4>
+    }
+
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathFieldMockServiceTest.java
@@ -1,7 +1,5 @@
 package io.micronaut.test.junit5;
 
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
@@ -14,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @MicronautTest
-@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+@MockitoEnabled
 class MathFieldMockServiceTest {
 
     @MockBean(MathServiceImpl.class) // <1>

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
@@ -1,7 +1,5 @@
 package io.micronaut.test.junit5;
 
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
@@ -17,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @MicronautTest
-@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+@MockitoEnabled
 class MathMockFieldCollaboratorTest {
 
     @MockBean(MathServiceImpl.class) // <1>

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
@@ -1,0 +1,47 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+public class MathMockFieldCollaboratorTest {
+
+    @MockBean(MathServiceImpl.class) // <1>
+    MathService mathService = mock(MathService.class);
+
+    @Inject
+    @Client("/")
+    HttpClient client; // <2>
+
+
+    @ParameterizedTest
+    @CsvSource({"2,4", "3,9"})
+    void testComputeNumToSquare(Integer num, Integer square) {
+
+        when( mathService.compute(num) )
+                .then(invocation -> Long.valueOf(Math.round(Math.pow(num, 2))).intValue());
+
+        final Integer result = client.toBlocking().retrieve(HttpRequest.GET("/math/compute/" + num), Integer.class); // <3>
+
+        assertEquals(
+                square,
+                result
+        );
+        verify(mathService).compute(num); // <4>
+    }
+
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMockFieldCollaboratorTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 @MicronautTest
 @Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
-public class MathMockFieldCollaboratorTest {
+class MathMockFieldCollaboratorTest {
 
     @MockBean(MathServiceImpl.class) // <1>
     MathService mathService = mock(MathService.class);

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MockitoCondition.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MockitoCondition.java
@@ -1,0 +1,18 @@
+package io.micronaut.test.junit5;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class MockitoCondition implements ExecutionCondition {
+    static final String MOCKITO_ENABLED = "mockito.test.enabled";
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        boolean isEnabled = Boolean.getBoolean(MOCKITO_ENABLED);
+        if (isEnabled) {
+            return ConditionEvaluationResult.enabled("Mockito enabled");
+        } else {
+            return ConditionEvaluationResult.disabled("Mockito disabled");
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MockitoEnabled.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MockitoEnabled.java
@@ -1,0 +1,16 @@
+package io.micronaut.test.junit5;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(MockitoCondition.class)
+public @interface MockitoEnabled {
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/MathFieldCollaboratorSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/MathFieldCollaboratorSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.test.spock
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@MicronautTest
+class MathFieldCollaboratorSpec extends Specification {
+
+    @MockBean(MathServiceImpl) // <1>
+    MathService mathService = Mock(MathService)
+
+    @Inject
+    @Client('/')
+    HttpClient client // <3>
+
+    @Unroll
+    void "should compute #num to #square"() {
+        when:
+        Integer result = client.toBlocking().retrieve(HttpRequest.GET('/math/compute/10'), Integer) // <3>
+
+        then:
+        1 * mathService.compute(10) >> Math.pow(num, 2)  // <4>
+        result == square
+
+        where:
+        num | square
+        2   | 4
+        3   | 9
+    }
+}


### PR DESCRIPTION
Micronaut 3.3 I believe introduced the ability to use fields as beans. This makes it possible to use `@MockBean` on a field which makes the test easier to read and is less verbose