### PR TITLE
Close the environment when stopping the application context

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -318,6 +318,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     protected void afterClass(C context) {
         stopEmbeddedApplication();
         if (applicationContext != null && applicationContext.isRunning()) {
+            applicationContext.getEnvironment().close();
             applicationContext.stop();
         }
         embeddedApplication = null;


### PR DESCRIPTION
This PR makes it sure that we close the environment before we stop
the application context. I noticed that when I was using `@MicronautTest`,
some resources weren't cleaned because the environment was never closed.