### PR TITLE
Add API to intercept the test method

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/context/TestMethodInterceptor.java
+++ b/test-core/src/main/java/io/micronaut/test/context/TestMethodInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.context;
+
+/**
+ * Test method interceptor. Intended to be used for API that doesn't support before/after phases.
+ *
+ * @param <R> The result type
+ * @author Denis Stepanov
+ * @since 3.4.0
+ */
+public interface TestMethodInterceptor<R> {
+
+    /**
+     * Intercepts before each test invocation.
+     *
+     * @param methodInvocationContext the method invocation context
+     * @return intercepted return value
+     * @throws Exception allows any exception to propagate
+     */
+    default R interceptBeforeEach(TestMethodInvocationContext<R> methodInvocationContext) throws Throwable {
+        return methodInvocationContext.proceed();
+    }
+
+    /**
+     * Intercepts each test invocation.
+     *
+     * @param methodInvocationContext the method invocation context
+     * @return intercepted return value
+     * @throws Exception allows any exception to propagate
+     */
+    default R interceptTest(TestMethodInvocationContext<R> methodInvocationContext) throws Throwable {
+        return methodInvocationContext.proceed();
+    }
+
+    /**
+     * Intercepts after each test invocation.
+     *
+     * @param methodInvocationContext the method invocation context
+     * @return intercepted return value
+     * @throws Exception allows any exception to propagate
+     */
+    default R interceptAfterEach(TestMethodInvocationContext<R> methodInvocationContext) throws Throwable {
+        return methodInvocationContext.proceed();
+    }
+
+}

--- a/test-core/src/main/java/io/micronaut/test/context/TestMethodInvocationContext.java
+++ b/test-core/src/main/java/io/micronaut/test/context/TestMethodInvocationContext.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.context;
+
+/**
+ * The test method invocation context.
+ *
+ * @param <R> The result type
+ * @author Denis Stepanov
+ * @since 3.4.0
+ */
+public interface TestMethodInvocationContext<R> {
+
+    /**
+     * @return current test context
+     */
+    TestContext getTestContext();
+
+    /**
+     * Proceed with the method invocation.
+     *
+     * @return The method return value
+     */
+    R proceed() throws Throwable;
+
+}

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.micronaut.test.context.TestMethodInvocationContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -106,16 +107,98 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     @Override
     public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        beforeSetupTest(buildContext(extensionContext));
-        invocation.proceed();
-        afterSetupTest(buildContext(extensionContext));
+        TestContext testContext = buildContext(extensionContext);
+        beforeSetupTest(testContext);
+        interceptBeforeEach(new TestMethodInvocationContext<Object>() {
+            @Override
+            public TestContext getTestContext() {
+                return testContext;
+            }
+
+            @Override
+            public Object proceed() throws Throwable {
+                return invocation.proceed();
+            }
+        });
+        afterSetupTest(testContext);
+    }
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        interceptTest(new TestMethodInvocationContext<Object>() {
+            TestContext testContext;
+
+            @Override
+            public TestContext getTestContext() {
+                if (testContext == null) {
+                    testContext = buildContext(extensionContext);
+                }
+                return testContext;
+            }
+
+            @Override
+            public Object proceed() throws Throwable {
+                return invocation.proceed();
+            }
+        });
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        interceptTest(new TestMethodInvocationContext<Object>() {
+            TestContext testContext;
+
+            @Override
+            public TestContext getTestContext() {
+                if (testContext == null) {
+                    testContext = buildContext(extensionContext);
+                }
+                return testContext;
+            }
+
+            @Override
+            public Object proceed() throws Throwable {
+                return invocation.proceed();
+            }
+        });
+    }
+
+    @Override
+    public <T> T interceptTestFactoryMethod(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        return (T) interceptTest(new TestMethodInvocationContext<Object>() {
+            TestContext testContext;
+
+            @Override
+            public TestContext getTestContext() {
+                if (testContext == null) {
+                    testContext = buildContext(extensionContext);
+                }
+                return testContext;
+            }
+
+            @Override
+            public Object proceed() throws Throwable {
+                return invocation.proceed();
+            }
+        });
     }
 
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        beforeCleanupTest(buildContext(extensionContext));
-        invocation.proceed();
-        afterCleanupTest(buildContext(extensionContext));
+        TestContext testContext = buildContext(extensionContext);
+        beforeCleanupTest(testContext);
+        interceptAfterEach(new TestMethodInvocationContext<Object>() {
+            @Override
+            public TestContext getTestContext() {
+                return testContext;
+            }
+
+            @Override
+            public Object proceed() throws Throwable {
+                return invocation.proceed();
+            }
+        });
+        afterCleanupTest(testContext);
     }
 
     @Override

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/InterceptTestTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/InterceptTestTest.java
@@ -49,7 +49,6 @@ class InterceptTestTest {
 
     @Test
     void testOk() {
-        Assertions.assertEquals("A", "A");
     }
 
     @Test

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/InterceptTestTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/InterceptTestTest.java
@@ -1,0 +1,88 @@
+
+package io.micronaut.test.junit5.intercept;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.junit5.MathService;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Property(name = "InterceptTestSpec", value = "true")
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InterceptTestTest {
+
+    @Inject
+    MathService mathService;
+
+    @Inject
+    TestInterceptor testInterceptor;
+
+    @BeforeEach
+    void myBeforeTest() {
+    }
+
+    @AfterEach
+    void myAfterEach() {
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2,8", "3,12"})
+    void testComputeNumToSquare(Integer num, Integer square) {
+        final Integer result = mathService.compute(num);
+
+        Assertions.assertEquals(
+                square,
+                result
+        );
+    }
+
+    @Test
+    void testOk() {
+        Assertions.assertEquals("A", "A");
+    }
+
+    @Test
+    void testInvocations() {
+        List<String> calls = new ArrayList<>(testInterceptor.calls);
+        List<String> expected = Arrays.asList(
+                "IN BEFORE testOk",
+                "OUT BEFORE testOk",
+                "IN testOk",
+                "OUT testOk",
+                "IN AFTER testOk",
+                "OUT AFTER testOk",
+                "IN BEFORE testComputeNumToSquare",
+                "OUT BEFORE testComputeNumToSquare",
+                "IN testComputeNumToSquare",
+                "OUT testComputeNumToSquare",
+                "IN AFTER testComputeNumToSquare",
+                "OUT AFTER testComputeNumToSquare",
+                "IN BEFORE testComputeNumToSquare",
+                "OUT BEFORE testComputeNumToSquare",
+                "IN testComputeNumToSquare",
+                "OUT testComputeNumToSquare",
+                "IN AFTER testComputeNumToSquare",
+                "OUT AFTER testComputeNumToSquare",
+                "IN BEFORE testInvocations",
+                "OUT BEFORE testInvocations",
+                "IN testInvocations"
+        );
+        Assertions.assertEquals(expected.size(), calls.size());
+        for (int i = 0; i < expected.size(); i++) {
+            String a = calls.get(i);
+            String b = expected.get(i);
+            Assertions.assertEquals(b, a);
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/TestInterceptor.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/intercept/TestInterceptor.java
@@ -1,0 +1,50 @@
+package io.micronaut.test.junit5.intercept;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.context.TestMethodInterceptor;
+import io.micronaut.test.context.TestMethodInvocationContext;
+import jakarta.inject.Singleton;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+@Property(name = "InterceptTestSpec", value = "true")
+class TestInterceptor implements TestMethodInterceptor {
+
+    public List<String> calls = new ArrayList<>();
+
+    @Override
+    public Object interceptBeforeEach(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod();
+        calls.add("IN BEFORE " + method.getName());
+        try {
+            return methodInvocationContext.proceed();
+        } finally {
+            calls.add("OUT BEFORE " + method.getName());
+        }
+    }
+
+    @Override
+    public Object interceptTest(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod();
+        calls.add("IN " + method.getName());
+        try {
+            return methodInvocationContext.proceed();
+        } finally {
+            calls.add("OUT " + method.getName());
+        }
+    }
+
+    @Override
+    public Object interceptAfterEach(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod();
+        calls.add("IN AFTER " + method.getName());
+        try {
+            return methodInvocationContext.proceed();
+        } finally {
+            calls.add("OUT AFTER " + method.getName());
+        }
+    }
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/MathService.java
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/MathService.java
@@ -1,8 +1,6 @@
 
 package io.micronaut.test.spock;
 
-import jakarta.inject.Singleton;
-
 public interface MathService {
 
     Integer compute(Integer num);

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/intercept/InterceptTestSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/intercept/InterceptTestSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.spock.intercept
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.spock.MathService
+import jakarta.inject.Inject
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.lang.Unroll
+
+@Stepwise
+@MicronautTest
+@Property(name = "InterceptTestSpec", value = "true")
+class InterceptTestSpec extends Specification {
+
+    @Inject
+    MathService mathService
+
+    @Inject
+    TestInterceptor testInterceptor
+
+    @Unroll
+    void "should compute #num to #expected"() {
+        when:
+            def result = mathService.compute(num)
+
+        then:
+            result == expected
+
+        where:
+            num | expected
+            2   | 8
+            3   | 12
+    }
+
+    void "my test"() {
+        expect:
+            1 == 1
+    }
+
+    void "validate invocations"() {
+        when:
+            def calls = new ArrayList(testInterceptor.calls)
+            def expected = [
+                    'IN $spock_feature_0_0',
+                    'IN BEFORE $spock_feature_0_0',
+                    'OUT BEFORE $spock_feature_0_0',
+                    'IN AFTER $spock_feature_0_0',
+                    'OUT AFTER $spock_feature_0_0',
+                    'IN BEFORE $spock_feature_0_0',
+                    'OUT BEFORE $spock_feature_0_0',
+                    'IN AFTER $spock_feature_0_0',
+                    'OUT AFTER $spock_feature_0_0',
+                    'OUT $spock_feature_0_0',
+
+                    'IN $spock_feature_0_1',
+                    'IN BEFORE $spock_feature_0_1',
+                    'OUT BEFORE $spock_feature_0_1',
+                    'IN AFTER $spock_feature_0_1',
+                    'OUT AFTER $spock_feature_0_1',
+                    'OUT $spock_feature_0_1',
+
+                    'IN $spock_feature_0_2',
+                    'IN BEFORE $spock_feature_0_2',
+                    'OUT BEFORE $spock_feature_0_2',
+                    //  This test is $spock_feature_0_2
+            ]
+        then:
+            assert calls.size() == expected.size()
+            for (int i = 0; i < expected.size(); i++) {
+                def a = calls.get(i)
+                def b = expected[i]
+                assert a == b
+            }
+    }
+
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/intercept/TestInterceptor.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/intercept/TestInterceptor.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.test.spock.intercept
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.context.TestMethodInterceptor
+import io.micronaut.test.context.TestMethodInvocationContext
+import jakarta.inject.Singleton
+
+import java.lang.reflect.Method
+
+@Singleton
+@Property(name = "InterceptTestSpec", value = "true")
+class TestInterceptor implements TestMethodInterceptor<Object> {
+
+    public List<String> calls = new ArrayList<>()
+
+    @Override
+    Object interceptBeforeEach(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod()
+        calls.add("IN BEFORE " + method.getName())
+        try {
+            return methodInvocationContext.proceed()
+        } finally {
+            calls.add("OUT BEFORE " + method.getName())
+        }
+    }
+
+    @Override
+    Object interceptTest(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod()
+        calls.add("IN " + method.getName())
+        try {
+            return methodInvocationContext.proceed()
+        } finally {
+            calls.add("OUT " + method.getName())
+        }
+    }
+
+    @Override
+    Object interceptAfterEach(TestMethodInvocationContext methodInvocationContext) throws Throwable {
+        Method method = (Method) methodInvocationContext.getTestContext().getTestMethod()
+        calls.add("IN AFTER " + method.getName())
+        try {
+            return methodInvocationContext.proceed()
+        } finally {
+            calls.add("OUT AFTER " + method.getName())
+        }
+    }
+}


### PR DESCRIPTION
There is a way to support Reactive/Async transactions for `@MicronautTest` using blocking but not every API supports splitting the start and end of the call like `before/after` ~ `begin/commit` so I need the interceptor for that.

The solution doesn't work for Kotest as it only exposes begin/end API.

Maybe there is a way to use the Micronaut method-interception...