### PR TITLE
fix: For Intercepted junit5 evalExecution disabled

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.micronaut.aop.Intercepted;
 import io.micronaut.test.context.TestMethodInvocationContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
@@ -249,6 +250,12 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             }
         } else {
             final Class<?> testClass = extensionContext.getRequiredTestClass();
+
+            // see https://github.com/micronaut-projects/micronaut-test/issues/640
+            if (Intercepted.class.isAssignableFrom(testClass)) {
+                return ConditionEvaluationResult.disabled("Intercepted Class is not a test");
+            }
+
             if (hasExpectedAnnotations(testClass) || isNestedTestClass(testClass)) {
                 return ConditionEvaluationResult.enabled("Test bean active");
             } else {


### PR DESCRIPTION
Close https://github.com/micronaut-projects/micronaut-test/issues/640

With Micronaut 3.6.3-SNAPSHOT

```
./gradlew testClasses
ls build/classes/java/test/example/micronaut/
$FruitDuplicationExceptionHandlerTest$Definition$Exec.class
$FruitDuplicationExceptionHandlerTest$Definition$Reference.class
$FruitDuplicationExceptionHandlerTest$Definition.class
FruitDuplicationExceptionHandlerTest.class
```

With Micronaut 3.7.0-SNAPSHOT

```
./gradlew testClasses
ls build/classes/java/test/example/micronaut/
$FruitDuplicationExceptionHandlerTest$Definition$Exec.class
$FruitDuplicationExceptionHandlerTest$Definition$Intercepted$Definition$Reference.class
$FruitDuplicationExceptionHandlerTest$Definition$Intercepted$Definition.class
$FruitDuplicationExceptionHandlerTest$Definition$Intercepted.class
$FruitDuplicationExceptionHandlerTest$Definition$Reference.class
$FruitDuplicationExceptionHandlerTest$Definition.class
FruitDuplicationExceptionHandlerTest.class
```

when running `./gradlew test` `MicronautJunit5Extension::evaluateExecutionCondition` is called twice

once for:

`$FruitDuplicationExceptionHandlerTest$Definition$Intercepted`

and another one for:

`FruitDuplicationExceptionHandlerTest`

This PR returns `ConditionEvaluationResult::disabled` for the former class which implements `Intercepted`.