### PR TITLE
Disable PTS for kotest tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
-projectVersion=3.6.3-SNAPSHOT
+projectVersion=3.7.0-SNAPSHOT
 projectGroup=io.micronaut.test
 micronautDocsVersion=2.0.0
-micronautVersion=3.5.1
-micronautTestVersion=3.1.1
+micronautVersion=3.7.1
+micronautTestVersion=3.6.2
+
 groovyVersion=3.0.10
 kotlinVersion=1.7.10
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotest5 = "5.4.2" # can not be managed until we deprecate kotest 4
 kotlin = "1.7.10"
 
 # Micronaut
-micronaut = "3.6.3"
+micronaut = "3.7.1"
 micronaut-gradle-plugin = "3.5.3"
 
 [libraries]

--- a/test-kotest/build.gradle
+++ b/test-kotest/build.gradle
@@ -39,6 +39,11 @@ test {
     useJUnitPlatform()
 }
 
+// PTS just skips Kotest tests silently...
+tasks.withType(Test).configureEach {
+    predictiveSelection.enabled = false
+}
+
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = '1.8'

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -39,6 +39,11 @@ test {
     useJUnitPlatform()
 }
 
+// PTS just skips Kotest tests silently...
+tasks.withType(Test).configureEach {
+    predictiveSelection.enabled = false
+}
+
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = '1.8'


### PR DESCRIPTION
Predictive Test Selection doesn't support Kotest, so it silently skips all the tests.

This change re-instates the tests by disabling it for our 2 kotest testsuites.