### PR TITLE
Fix nativeTest with Groovy 4

### DIFF
--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -20,7 +20,7 @@ tasks.withType(Test).configureEach {
 
 configurations {
     nativeImageTestClasspath {
-        exclude(group: 'org.codehaus.groovy')
+        exclude(group: 'org.apache.groovy')
     }
 }
 


### PR DESCRIPTION
NativeTest was failing on Master since the Kotest removal and upgrade to Groovy 4.

https://github.com/micronaut-projects/micronaut-test/actions/runs/3219707539