### PR TITLE
Update reason for disabling Predictive Test Selection

### DIFF
--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -41,11 +41,11 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
-}
-
-// PTS just skips Kotest tests silently...
-tasks.withType(Test).configureEach {
+    useJUnitPlatform {
+        includeEngines("kotest")
+    }
+    // PTS fails for Kotest because it's not supported, yet.
+    // see https://docs.gradle.com/enterprise/predictive-test-selection/#_frameworks_and_languages
     predictiveSelection.enabled = false
 }
 


### PR DESCRIPTION
Starting with v3.11.2 of the Gradle Enterprise Gradle plugin, PTS
detects unsupported test engines and fails test discovery for Kotest
since it's not yet supported.
