### PR TITLE
Adding JUnit-Jupiter Params dependency

### DIFF
--- a/src/main/docs/guide/junit5.adoc
+++ b/src/main/docs/guide/junit5.adoc
@@ -11,6 +11,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("io.micronaut.test:micronaut-test-junit5:{version}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:{junitVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:{junitVersion}")
 }
 
 // use JUnit 5 platform


### PR DESCRIPTION
Without JUnit-Jupiter-Params dependency, @ParameterizedTest annotation is not available to the implementation test classes.