### PR TITLE
Fix publication on the 4.0.0 branch

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.0.0"
+    id("io.micronaut.build.shared.settings") version "6.0.1"
 }
 
 dependencyResolutionManagement {

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.library' // Required to configure Graal for nativeTest
+    id 'io.micronaut.graalvm' // Required to configure Graal for nativeTest
     id "io.micronaut.build.internal.base-module"
 }
 


### PR DESCRIPTION
When we use 'io.micronaut.library', we end up with multiple POMs in the published POM we generate.

We were using this to get nativeTest to pass.  Switching this to 'io.micronaut.graalvm' still allows this.

But it does not generate an invalid POM

Also updated the shared setting plugin whilst I was here