### PR TITLE
build: add jackson-databind test dependency

### DIFF
--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.params)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.jackson.databind)
     testImplementation(libs.managed.mockito.junit.jupiter)
     testImplementation(libs.managed.hamcrest)
     testImplementation(mn.micronaut.data.tx)

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.jackson.databind)
 
     testImplementation(mn.micronaut.data.tx)
     testImplementation(mn.micronaut.data.hibernate.jpa)

--- a/test-rest-assured/build.gradle
+++ b/test-rest-assured/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation project(":test-junit5")
     testImplementation(mn.micronaut.http.server.netty)
+
     testImplementation(libs.managed.hamcrest)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(mn.micronaut.jackson.databind)

--- a/test-rest-assured/build.gradle
+++ b/test-rest-assured/build.gradle
@@ -32,4 +32,5 @@ dependencies {
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(libs.managed.hamcrest)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(mn.micronaut.jackson.databind)
 }

--- a/test-spock/build.gradle
+++ b/test-spock/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.groovy)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.jackson.databind)
 
     testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.hibernate.validator)


### PR DESCRIPTION
Added jackson databind testImplementation dependency to get rid of:

```
  Caused by: io.micronaut.context.exceptions.BeanContextException: Error loading bean [io.micronaut.http.server.exceptions.response.HateoasErrorResponseProcessor]: io/micronaut/json/JsonConfiguration
```

Now I get:

```
  Caused by: io.micronaut.context.exceptions.NoSuchBeanException: No bean of type [io.micronaut.core.convert.ConversionService<io.micronaut.core.convert.ConversionService<io.micronaut.core.convert.ConversionService>>] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
```