### PR TITLE
Revert mockk for kotlin 1.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 managed-assertj = "3.24.2"
 managed-hamcrest = "2.2"
 managed-mockito = "4.11.0"
-managed-mockk = "1.13.4"
+managed-mockk = "1.12.8"
 managed-kotest = "4.6.4"
 managed-junit = "5.9.2"
 managed-spock = "2.1-groovy-3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 managed-assertj = "3.24.2"
 managed-hamcrest = "2.2"
 managed-mockito = "4.11.0"
-managed-mockk = "1.12.8"
+managed-mockk = "1.13.3" # can not be upgraded to 1.13.4+ until 4.x, due to breaking change on kotlin 1.8 transitive dependency
 managed-kotest = "4.6.4"
 managed-junit = "5.9.2"
 managed-spock = "2.1-groovy-3.0"


### PR DESCRIPTION
This reverts the prior mockk 1.13.4 update due to breaking change. mockk 1.12.28 to 1.13.3 uses kotlin 1.17.20 and mockk 1.13.4 changes that to kotlin 1.8.0. See https://github.com/mockk/mockk/blob/cac70d917c4cd37c9390bb3661650f6b4f09277c/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt#LL14C19-L14C19, which introduces a binary incompatibility. 

1.13.3 is the last version that can be used until Micronaut 4.x (which uses kotlin 1.8+).