### PR TITLE
Upgrade to Kotest 5.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ managed-mockito = "5.2.0"
 managed-mockk = "1.13.4"
 managed-junit = "5.9.2"
 managed-rest-assured = "5.3.0"
-managed-kotest = "5.6.0"
+managed-kotest = "5.6.1"
 managed-spock = "2.3-groovy-4.0"
 
 kotlin = "1.8.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ managed-mockito = "5.2.0"
 managed-mockk = "1.13.4"
 managed-junit = "5.9.2"
 managed-rest-assured = "5.3.0"
-managed-kotest = "5.5.5"
+managed-kotest = "5.6.0"
 managed-spock = "2.3-groovy-4.0"
 
 kotlin = "1.8.10"


### PR DESCRIPTION
This version of Kotest supports Predictive Tests (so we can undo https://github.com/micronaut-projects/micronaut-core/pull/8612)

**It requires Kotlin 1.8+ so needs to be for Micronaut 4.0.0**