### PR TITLE
Add dynamic registration of test property providers

### DIFF
--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.micronaut-test-module"
+    id "java-test-fixtures"
 }
 
 dependencies {
@@ -15,3 +16,7 @@ jar {
     exclude "io/micronaut/test/extensions/spock/*"
     exclude "io/micronaut/test/extensions/junit5/*"
 }
+
+// Temporarily disable publishing of test fixtures until we depend on a released version of Data
+components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -17,7 +17,9 @@ package io.micronaut.test.extensions;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.DefaultApplicationContextBuilder;
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.env.DefaultEnvironment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.core.annotation.Nullable;
@@ -41,18 +43,29 @@ import io.micronaut.test.context.TestExecutionListener;
 import io.micronaut.test.context.TestMethodInterceptor;
 import io.micronaut.test.context.TestMethodInvocationContext;
 import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.test.support.TestPropertyProviderFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.AnnotatedElement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
 
 /**
  * Abstract base class for both JUnit 5 and Spock.
  *
+ * @param <C> The extension context
  * @author graemerocher
  * @since 1.0
- * @param <C> The extension context
  */
 public abstract class AbstractMicronautExtension<C> implements TestExecutionListener, TestMethodInterceptor<Object> {
     public static final String TEST_ROLLBACK = "micronaut.test.rollback";
@@ -149,7 +162,9 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         });
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void beforeTestExecution(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::beforeTestExecution, testContext, false);
@@ -165,19 +180,25 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         fireListeners(TestExecutionListener::afterCleanupTest, testContext, true);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void afterTestExecution(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::afterTestExecution, testContext, true);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void beforeTestClass(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::beforeTestClass, testContext, false);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void afterTestClass(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::afterTestClass, testContext, true);
@@ -193,13 +214,17 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         fireListeners(TestExecutionListener::afterSetupTest, testContext, true);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void beforeTestMethod(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::beforeTestMethod, testContext, false);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void afterTestMethod(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::afterTestMethod, testContext, true);
@@ -285,10 +310,6 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                     }
                 }
             }
-            if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
-                resolveTestProperties(context, testAnnotationValue, testProperties);
-            }
-
             testProperties.put(TestActiveCondition.ACTIVE_SPEC_CLAZZ, testClass);
             testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotationValue.rollback()));
             testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
@@ -302,11 +323,14 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 environments = new String[]{"test"};
             }
             builder.packages(testAnnotationValue.packages())
-                   .environments(environments);
-
+                .environments(environments);
+            loadPropertySourcesFromServicesLoaders(environments, testProperties, testClass);
+            if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
+                resolveTestProperties(context, testAnnotationValue, testProperties);
+            }
             PropertySource testPropertySource = PropertySource.of(
-                    TEST_PROPERTY_SOURCE,
-                    testProperties
+                TEST_PROPERTY_SOURCE,
+                testProperties
             );
             builder.propertySources(testPropertySource);
             postProcessBuilder(builder);
@@ -321,8 +345,49 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         }
     }
 
+    private void loadPropertySourcesFromServicesLoaders(String[] environments, Map<String, Object> testProperties, Class<?> testClass) {
+        if (builder instanceof DefaultApplicationContextBuilder dacb) {
+            ServiceLoader<TestPropertyProviderFactory> factories = ServiceLoader.load(TestPropertyProviderFactory.class);
+            for (TestPropertyProviderFactory factory : factories) {
+                var props = new HashMap<String, Object>();
+                props.putAll(testProperties);
+                var services = SoftServiceLoader.load(PropertySourceLoader.class, this.getClass().getClassLoader());
+                var env = new DefaultEnvironment(dacb);
+                for (ServiceDefinition<PropertySourceLoader> service : services) {
+                    try {
+                        PropertySourceLoader loader = service.load();
+                        loader.load(env).ifPresent(available -> {
+                            for (String key : available) {
+                                props.put(key, available.get(key));
+                            }
+                        });
+                        for (String name : environments) {
+                            Optional<PropertySource> propertySource = loader.load("application-" + name, env);
+                            propertySource.ifPresent(available -> {
+                                    for (String key : available) {
+                                        props.put(key, available.get(key));
+                                    }
+                                }
+                            );
+                        }
+                    } catch (ServiceConfigurationError ex) {
+                        // some property source loaders like YAML may be present
+                        // on classpath, but the dependencies like SnakeYAML aren't
+                        // in which case we silently ignore
+                        if (!(ex.getCause() instanceof NoClassDefFoundError)) {
+                            throw ex;
+                        }
+                    }
+                }
+                var provider = factory.create(Collections.unmodifiableMap(props), testClass);
+                this.testProperties.putAll(provider.get());
+            }
+        }
+    }
+
     /**
      * Allows subclasses to customize the builder right before context initialization.
+     *
      * @param builder the application context builder
      */
     protected void postProcessBuilder(ApplicationContextBuilder builder) {
@@ -330,7 +395,8 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
 
     /**
      * Resolves any test properties.
-     *  @param context The test context
+     *
+     * @param context The test context
      * @param testAnnotationValue The test annotation
      * @param testProperties The test properties
      */
@@ -351,7 +417,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 for (Property property : propertyAnnotations) {
                     final String name = property.name();
                     oldValues.put(name,
-                            testProperties.put(name, property.value())
+                        testProperties.put(name, property.value())
                     );
                 }
             } else {
@@ -379,7 +445,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
             if (applicationContext != null) {
                 if (refreshScope != null) {
                     refreshScope.onRefreshEvent(new RefreshEvent(Collections.singletonMap(
-                            TestActiveCondition.ACTIVE_MOCKS, "changed"
+                        TestActiveCondition.ACTIVE_MOCKS, "changed"
                     )));
                 }
                 applicationContext.inject(testInstance);
@@ -411,7 +477,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     public void afterEach(C context) throws Exception {
         if (refreshScope != null) {
             if (!oldValues.isEmpty()) {
-                for (Map.Entry<String, Object> entry: oldValues.entrySet()) {
+                for (Map.Entry<String, Object> entry : oldValues.entrySet()) {
                     Object value = entry.getValue();
                     if (value != null) {
                         testProperties.put(entry.getKey(), value);
@@ -444,7 +510,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         String prefix = requiredTestClass.getPackage().getName() + ".$" + requiredTestClass.getSimpleName();
         final ClassLoader classLoader = requiredTestClass.getClassLoader();
         return ClassUtils.isPresent(prefix + "Definition", classLoader) ||
-                ClassUtils.isPresent(prefix + "$Definition", classLoader);
+               ClassUtils.isPresent(prefix + "$Definition", classLoader);
     }
 
     /**

--- a/test-core/src/main/java/io/micronaut/test/support/TestPropertyProviderFactory.java
+++ b/test-core/src/main/java/io/micronaut/test/support/TestPropertyProviderFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.support;
+
+import java.util.Map;
+
+/**
+ * A test property provider factory is responsible for generating
+ * a test property provider which is going to be called during test
+ * setup, as any other {@link TestPropertyProvider}. However, such
+ * a provider is discovered via service loading, and has access to
+ * the current test class, as well as the currently available set
+ * of resolved test properties.
+ *
+ * This can be used as an extension mechanism for modules which
+ * can provide test properties, for example Micronaut Test Resources.
+ *
+ * @since 4.0.0
+ */
+@FunctionalInterface
+public interface TestPropertyProviderFactory {
+    /**
+     * Creates a new test property provider.
+     * @param availableProperties the test properties which are already
+     * resolved at the point this method is called.
+     * @param testClass the test class
+     * @return a test property provider
+     */
+    TestPropertyProvider create(Map<String, Object> availableProperties, Class<?> testClass);
+}

--- a/test-core/src/main/java/io/micronaut/test/support/TestPropertyProviderFactory.java
+++ b/test-core/src/main/java/io/micronaut/test/support/TestPropertyProviderFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2003-2021 the original author or authors.
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test-core/src/testFixtures/java/io/micronaut/test/core/fixtures/DummyTestPropertyProvider.java
+++ b/test-core/src/testFixtures/java/io/micronaut/test/core/fixtures/DummyTestPropertyProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.core.fixtures;
+
+import io.micronaut.test.support.TestPropertyProvider;
+
+import java.util.Map;
+
+public class DummyTestPropertyProvider implements TestPropertyProvider {
+    private final Map<String, Object> availableProperties;
+    private final Class<?> testClass;
+
+    public DummyTestPropertyProvider(Map<String, Object> availableProperties, Class<?> testClass) {
+        this.availableProperties = availableProperties;
+        this.testClass = testClass;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        var fromConf = availableProperties.getOrDefault("some.property", "not found");
+        return Map.of(
+            "this-test-class", testClass.getName(),
+            "derived-from-config", fromConf + " and derived in provider"
+        );
+    }
+}

--- a/test-core/src/testFixtures/java/io/micronaut/test/core/fixtures/DummyTestPropertyProviderFactory.java
+++ b/test-core/src/testFixtures/java/io/micronaut/test/core/fixtures/DummyTestPropertyProviderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.core.fixtures;
+
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.test.support.TestPropertyProviderFactory;
+
+import java.util.Map;
+
+public class DummyTestPropertyProviderFactory implements TestPropertyProviderFactory {
+    @Override
+    public TestPropertyProvider create(Map<String, Object> availableProperties, Class<?> testClass) {
+        return new DummyTestPropertyProvider(availableProperties, testClass);
+    }
+}

--- a/test-core/src/testFixtures/resources/META-INF/services/io.micronaut.test.support.TestPropertyProviderFactory
+++ b/test-core/src/testFixtures/resources/META-INF/services/io.micronaut.test.support.TestPropertyProviderFactory
@@ -1,0 +1,1 @@
+io.micronaut.test.core.fixtures.DummyTestPropertyProviderFactory

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testRuntimeOnly(mnSql.h2)
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(testFixtures(projects.micronautTestCore))
 }
 
 graalvmNative {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/props/TestPropertyProviderFactoryTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/props/TestPropertyProviderFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.junit5.props;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.junit5.BaseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(environments = "testenv1")
+public class TestPropertyProviderFactoryTest extends BaseTest {
+
+    @Value("${this-test-class}")
+    private String thisTestClass;
+
+    @Value("${derived-from-config}")
+    private String derivedFromConfig;
+
+    @Test
+    void testFactoryWasCalled() {
+        assertEquals(TestPropertyProviderFactoryTest.class.getName(), thisTestClass);
+    }
+
+    @Test
+    void providerCanDeriveProperties() {
+        assertEquals("visible in tests and derived in provider", derivedFromConfig);
+    }
+}

--- a/test-junit5/src/test/resources/application-testenv1.yml
+++ b/test-junit5/src/test/resources/application-testenv1.yml
@@ -1,0 +1,2 @@
+some:
+  property: "visible in tests"

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.snakeyaml)
     testImplementation(libs.managed.kotest.assertions.core.jvm)
+    testRuntimeOnly(testFixtures(projects.micronautTestCore))
 }
 
 tasks.named("test") {

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TestPropertiesFactoryCtorInjectionTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TestPropertiesFactoryCtorInjectionTest.kt
@@ -1,0 +1,19 @@
+
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+@MicronautTest
+class TestPropertiesFactoryCtorInjectionTest(
+    @Value("\${this-test-class}") val thisTestClass: String
+) : StringSpec() {
+    init {
+        "property should be injected" {
+            thisTestClass shouldBe TestPropertiesFactoryCtorInjectionTest::class.qualifiedName
+        }
+    }
+}

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TestPropertiesFactoryTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TestPropertiesFactoryTest.kt
@@ -1,0 +1,19 @@
+
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+@MicronautTest
+class TestPropertiesFactoryTest() : StringSpec() {
+    @Value("\${this-test-class}") lateinit var thisTestClass: String
+
+    init {
+        "property should be injected" {
+            thisTestClass shouldBe TestPropertiesFactoryTest::class.qualifiedName
+        }
+    }
+}

--- a/test-spock/build.gradle
+++ b/test-spock/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     testRuntimeOnly(mnSql.h2)
+    testRuntimeOnly(testFixtures(projects.micronautTestCore))
 }

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/props/TestPropertiesProviderFactoryTest.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/props/TestPropertiesProviderFactoryTest.groovy
@@ -1,0 +1,17 @@
+package io.micronaut.test.spock.props
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+
+@MicronautTest
+class TestPropertiesProviderFactoryTest {
+
+    @Value('${this-test-class}')
+    String thisTestClass
+
+    void "test properties provider is called"() {
+        expect:
+        thisTestClass == TestPropertiesProviderFactoryTest.class.name
+    }
+
+}


### PR DESCRIPTION
This commit introduces a new way to supply test properties to tests, by implementing a `TestPropertyProviderFactory`. These factories are loaded via service loading and are responsible for instantiating a `TestPropertyProvider`.

In order to be able to dynamically provide properties, the factory is provided with the current test class, and the set of properties which are already available at the moment the provider is called.

This means that contrary to a typical `TestPropertyProvider`, this provider has access to "raw" configuration, as supplied by `PropertySourceLoader`.

This will permit the implementation of a new test resources module which will be capable of dynamically supplying test properties to test classes _before_ the application context is available, and without having to explicitly call the test resources client.