### PR TITLE
Use and export kotest-bom for kotest dependencies management

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,11 +41,13 @@ managed-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "managed-ha
 managed-mockito-core = { module = "org.mockito:mockito-core", version.ref = "managed-mockito" }
 managed-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "managed-mockito" }
 managed-mockk = { module = "io.mockk:mockk", version.ref = "managed-mockk" }
+# TODO kotest libs should stop be directly managed, boms-kotest should define the versions
 managed-kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "managed-kotest" }
 managed-kotest-runner-junit5-jvm = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "managed-kotest" }
 
 # BOMs
 boms-junit = { module = "org.junit:junit-bom", version.ref = "managed-junit" }
+boms-kotest = { module = "io.kotest:kotest-bom", version.ref = "managed-kotest" }
 boms-spock = { module = "org.spockframework:spock-bom", version.ref = "managed-spock" }
 boms-rest-assured = { module = "io.rest-assured:rest-assured-bom", version.ref = "managed-rest-assured" }
 

--- a/test-bom/build.gradle
+++ b/test-bom/build.gradle
@@ -2,6 +2,10 @@ plugins {
     id "io.micronaut.build.internal.bom"
 }
 
+repositories {
+    gradlePluginPortal() // needed for checkBom task to resolve plugin dependencies defined in kotest-pom
+}
+
 micronautBom {
     suppressions {
         acceptedLibraryRegressions.add("micronaut-test-kotest")

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     api projects.micronautTestCore
     api(mn.micronaut.context)
+    api(platform(libs.boms.kotest))
     api(libs.managed.kotest.runner.junit5.jvm)
 
     implementation(mn.micronaut.inject)


### PR DESCRIPTION
micronaut-test-kotest5 now uses and exposes kotest-bom

Related PR into micronaut-platform: https://github.com/micronaut-projects/micronaut-platform/pull/901
Closes #843