### PR TITLE
Removed hardcoded version of metadata repo

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ micronaut-spring = "5.0.0"
 micronaut-sql = "5.0.0"
 micronaut-reactor = "3.0.0"
 
-micronaut-gradle-plugin = "4.0.0"
+micronaut-gradle-plugin = "4.0.3"
 
 [libraries]
 # Core

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -64,7 +64,6 @@ dependencies {
 graalvmNative {
     metadataRepository {
         enabled = true
-        version = "0.3.1"
     }
     binaries {
         test {


### PR DESCRIPTION
The latest version which comes via micronaut gradle and native build tool plugins needs to be used.