### PR TITLE
Support multiple Kotest spec instances

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,5 +19,8 @@ max_line_length = 100
 # Import order can be configured with ij_java_imports_layout=...
 # See documentation https://youtrack.jetbrains.com/issue/IDEA-170643#focus=streamItem-27-3708697.0-0
 
+[*.kt]
+indent_size = 4
+
 [*.xml]
 indent_size = 4

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Context.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Context.kt
@@ -47,6 +47,10 @@ class MicronautKotest5Context(
     override fun alignMocks(context: Spec?, instance: Any) {
     }
 
+    fun isApplicationContextOpen(): Boolean {
+        return applicationContext != null
+    }
+
     fun beforeSpecClass(spec: Spec) {
         if (!createBean) {
             beforeClass(spec, testClass, micronautTestValue)
@@ -115,8 +119,4 @@ class MicronautKotest5Context(
             false
         )
     }
-
-  fun close() {
-      applicationContext.close()
-  }
 }

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Context.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Context.kt
@@ -116,4 +116,7 @@ class MicronautKotest5Context(
         )
     }
 
+  fun close() {
+      applicationContext.close()
+  }
 }

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
@@ -33,7 +33,6 @@ object MicronautKotest5Extension : TestListener, ConstructorExtension, TestCaseE
         testCase: TestCase,
         execute: suspend (TestCase) -> TestResult
     ): TestResult {
-//        val context = contexts[testCase.spec]
         val context = testCase.spec.context()
         return if (context != null && context.getSpecDefinition() == null) {
             // It's a MicronautTest test where the bean doesn't exist
@@ -43,9 +42,7 @@ object MicronautKotest5Extension : TestListener, ConstructorExtension, TestCaseE
             execute(testCase)
         }
     }
-
-//    val contexts: MutableMap<Spec, MicronautKotest5Context> = mutableMapOf()
-
+    
     val contexts: MutableMap<String, List<MicronautKotest5Context>> = mutableMapOf()
 
     private fun Spec.context() =

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
@@ -51,6 +51,7 @@ object MicronautKotest5Extension: TestListener, ConstructorExtension, TestCaseEx
 
     override suspend fun afterSpec(spec: Spec) {
         contexts[spec.javaClass.name]?.afterSpecClass(spec)
+        contexts[spec.javaClass.name]?.close()
     }
 
     override suspend fun beforeTest(testCase: TestCase) {

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
@@ -27,14 +27,15 @@ import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 
-object MicronautKotest5Extension: TestListener, ConstructorExtension, TestCaseExtension {
+object MicronautKotest5Extension : TestListener, ConstructorExtension, TestCaseExtension {
 
     override suspend fun intercept(
         testCase: TestCase,
         execute: suspend (TestCase) -> TestResult
     ): TestResult {
-        val context = contexts[testCase.spec.javaClass.name]
-        return if(context != null && context.getSpecDefinition() == null) {
+//        val context = contexts[testCase.spec]
+        val context = testCase.spec.context()
+        return if (context != null && context.getSpecDefinition() == null) {
             // It's a MicronautTest test where the bean doesn't exist
             TestResult.Ignored
         } else {
@@ -43,39 +44,43 @@ object MicronautKotest5Extension: TestListener, ConstructorExtension, TestCaseEx
         }
     }
 
-    val contexts: MutableMap<String, MicronautKotest5Context> = mutableMapOf()
+//    val contexts: MutableMap<Spec, MicronautKotest5Context> = mutableMapOf()
+
+    val contexts: MutableMap<String, List<MicronautKotest5Context>> = mutableMapOf()
+
+    private fun Spec.context() =
+        contexts[javaClass.name]?.find { it.bean == this } ?: contexts[javaClass.name]?.find { it.bean == null }
 
     override suspend fun beforeSpec(spec: Spec) {
-        contexts[spec.javaClass.name]?.beforeSpecClass(spec)
+        spec.context()?.beforeSpecClass(spec)
     }
 
     override suspend fun afterSpec(spec: Spec) {
-        contexts[spec.javaClass.name]?.afterSpecClass(spec)
-        contexts[spec.javaClass.name]?.close()
+        spec.context()?.afterSpecClass(spec)
     }
 
     override suspend fun beforeTest(testCase: TestCase) {
-        contexts[testCase.spec.javaClass.name]?.beforeTest(testCase)
+        testCase.spec.context()?.beforeTest(testCase)
     }
 
     override suspend fun afterTest(testCase: TestCase, result: TestResult) {
-        contexts[testCase.spec.javaClass.name]?.afterTest(testCase, result)
+        testCase.spec.context()?.afterTest(testCase, result)
     }
 
     override suspend fun beforeInvocation(testCase: TestCase, iteration: Int) {
-        contexts[testCase.spec.javaClass.name]?.beforeInvocation(testCase)
+        testCase.spec.context()?.beforeInvocation(testCase)
     }
 
     override suspend fun afterInvocation(testCase: TestCase, iteration: Int) {
-        contexts[testCase.spec.javaClass.name]?.afterInvocation(testCase)
+        testCase.spec.context()?.afterInvocation(testCase)
     }
 
     override suspend fun beforeContainer(testCase: TestCase) {
-        contexts[testCase.spec.javaClass.name]?.beforeInvocation(testCase)
+        testCase.spec.context()?.beforeInvocation(testCase)
     }
 
     override suspend fun afterContainer(testCase: TestCase, result: TestResult) {
-        contexts[testCase.spec.javaClass.name]?.afterInvocation(testCase)
+        testCase.spec.context()?.afterInvocation(testCase)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -83,16 +88,17 @@ object MicronautKotest5Extension: TestListener, ConstructorExtension, TestCaseEx
         val constructor = clazz.primaryConstructor
         val testClass: Class<Any> = clazz.java as Class<Any>
         val micronautTestValue = testClass
-                    .annotations
-                    .filterIsInstance<MicronautTest>()
-                    .map { micronautTest -> buildValueObject(micronautTest) }
-                    .firstOrNull()
+            .annotations
+            .filterIsInstance<MicronautTest>()
+            .map { micronautTest -> buildValueObject(micronautTest) }
+            .firstOrNull()
         return if (micronautTestValue == null) {
             null
         } else {
             val createBean = constructor != null && constructor.parameters.isNotEmpty()
             val context = MicronautKotest5Context(testClass, micronautTestValue, createBean)
-            contexts[testClass.name] = context
+            val specContexts = contexts[testClass.name] ?: emptyList()
+            contexts[testClass.name] = specContexts + context
             if (createBean) {
                 context.bean
             } else {
@@ -103,17 +109,17 @@ object MicronautKotest5Extension: TestListener, ConstructorExtension, TestCaseEx
 
     private fun buildValueObject(micronautTest: MicronautTest): MicronautTestValue {
         return MicronautTestValue(
-                micronautTest.application.java,
-                micronautTest.environments,
-                micronautTest.packages,
-                micronautTest.propertySources,
-                micronautTest.rollback,
-                micronautTest.transactional,
-                micronautTest.rebuildContext,
-                micronautTest.contextBuilder.map { kClass -> kClass.java }.toTypedArray(),
-                micronautTest.transactionMode,
-                micronautTest.startApplication,
-                false
+            micronautTest.application.java,
+            micronautTest.environments,
+            micronautTest.packages,
+            micronautTest.propertySources,
+            micronautTest.rollback,
+            micronautTest.transactional,
+            micronautTest.rebuildContext,
+            micronautTest.contextBuilder.map { kClass -> kClass.java }.toTypedArray(),
+            micronautTest.transactionMode,
+            micronautTest.startApplication,
+            false
         )
     }
 

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/IsolationModeTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/IsolationModeTest.kt
@@ -1,0 +1,38 @@
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+class IsolationModeTest : FunSpec({
+
+    test("extension should support multiple instances per spec to handle isolation modes") {
+        val a = MicronautKotest5Extension.instantiate(IsolatedTests::class).shouldNotBeNull()
+        val b = MicronautKotest5Extension.instantiate(IsolatedTests::class).shouldNotBeNull()
+        a.hashCode() shouldNotBe b.hashCode()
+        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
+            .shouldNotBeNull()
+            .shouldHaveSize(2)
+        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
+            .shouldNotBeNull()
+            .forAll { it.isApplicationContextOpen() }
+        MicronautKotest5Extension.afterSpec(a)
+        MicronautKotest5Extension.afterSpec(b)
+        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
+            .shouldNotBeNull()
+            .forAll { !it.isApplicationContextOpen() }
+    }
+})
+
+@MicronautTest
+// need a parameter here so the extension instantiates the spec
+private class IsolatedTests(private val mathService: MathService) : FunSpec() {
+    init {
+        test("test1") {}
+        test("test2") {}
+    }
+}


### PR DESCRIPTION
Hi Micronaut folks!

~I think the application context should be closed when a Kotest spec finishes executing, otherwise the resources are not cleaned up.~

Kotest5Context needs to support multiple instances of specs. 

See bug report here: https://github.com/kotest/kotest/issues/3711