### PR TITLE
MicronautKotest5Extension does not retain contexts anymore after test spec is done

### DIFF
--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/IsolationModeTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/IsolationModeTest.kt
@@ -14,17 +14,12 @@ class IsolationModeTest : FunSpec({
         val a = MicronautKotest5Extension.instantiate(IsolatedTests::class).shouldNotBeNull()
         val b = MicronautKotest5Extension.instantiate(IsolatedTests::class).shouldNotBeNull()
         a.hashCode() shouldNotBe b.hashCode()
-        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
-            .shouldNotBeNull()
-            .shouldHaveSize(2)
-        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
-            .shouldNotBeNull()
-            .forAll { it.isApplicationContextOpen() }
+        val contexts = MicronautKotest5Extension.contexts[IsolatedTests::class.java.name].shouldNotBeNull().toList()
+        contexts.shouldHaveSize(2)
+        contexts.forAll { it.isApplicationContextOpen() }
         MicronautKotest5Extension.afterSpec(a)
         MicronautKotest5Extension.afterSpec(b)
-        MicronautKotest5Extension.contexts[IsolatedTests::class.java.name]
-            .shouldNotBeNull()
-            .forAll { !it.isApplicationContextOpen() }
+        contexts.forAll { !it.isApplicationContextOpen() }
     }
 })
 

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/NoContextsRetentionTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/NoContextsRetentionTest.kt
@@ -1,0 +1,29 @@
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+class NoContextsRetentionTest : FunSpec({
+    test("extension should not retain references to contexts after tests are finished") {
+        MicronautKotest5Extension.contexts[NoContextsRetentionTests::class.java.name].shouldBeNull()
+        val a = MicronautKotest5Extension.instantiate(NoContextsRetentionTests::class).shouldNotBeNull()
+        val b = MicronautKotest5Extension.instantiate(NoContextsRetentionTests::class).shouldNotBeNull()
+        MicronautKotest5Extension.contexts[NoContextsRetentionTests::class.java.name].shouldNotBeNull().shouldHaveSize(2)
+        MicronautKotest5Extension.afterSpec(a)
+        MicronautKotest5Extension.contexts[NoContextsRetentionTests::class.java.name].shouldNotBeNull().shouldHaveSize(1)
+        MicronautKotest5Extension.afterSpec(b)
+        MicronautKotest5Extension.contexts[NoContextsRetentionTests::class.java.name].shouldBeNull()
+    }
+})
+
+@MicronautTest
+// need a parameter here so the extension instantiates the spec
+private class NoContextsRetentionTests(private val mathService: MathService) : FunSpec() {
+    init {
+        test("test1") {}
+    }
+}


### PR DESCRIPTION
This addresses a memory leak caused by `MicronautKotest5Extension` retaining all created `MicronautKotest5Context` that in turn retain all `ApplicationContext`s

Closes #861