### PR TITLE
fix: TestSqlAnnotationHandler fails if context stopped in test

### DIFF
--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationStopTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationStopTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
 class ApplicationStopTest {
@@ -18,8 +19,9 @@ class ApplicationStopTest {
     private ApplicationContext applicationContext;
 
     @Test
-    void embeddedApplicationIsNotStartedWhenContextIsStarted() {
+    void stoppingTheContextDoesntCauseFailures() {
         applicationContext.stop();
+        assertTrue(true);
         // should not error
     }
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationStopTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationStopTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@MicronautTest
+class ApplicationStopTest {
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Test
+    void embeddedApplicationIsNotStartedWhenContextIsStarted() {
+        applicationContext.stop();
+        // should not error
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceApplicationStopTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceApplicationStopTest.java
@@ -1,0 +1,59 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.annotation.Sql;
+import io.micronaut.test.annotation.TransactionMode;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DbProperties
+@MicronautTest(transactionMode = TransactionMode.SINGLE_TRANSACTION)
+@Property(name = "datasources.default.dialect", value = "H2")
+@Property(name = "datasources.default.driverClassName", value = "org.h2.Driver")
+@Property(name = "datasources.default.schema-generate", value = "CREATE_DROP")
+@Property(name = "datasources.default.url", value = "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
+@Property(name = "datasources.default.username", value = "sa")
+@Sql({"classpath:create.sql", "classpath:datasource_1_insert.sql"}) // <1>
+class SqlDatasourceApplicationStopTest {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    DataSource dataSource;
+
+    @Test
+    void stoppingTheContextDoesntCauseFailures() throws Exception {
+        assertEquals(List.of("Aardvark", "Albatross"), readAllNames(dataSource));
+        applicationContext.stop();
+        assertTrue(true);
+        // should not error
+    }
+
+    List<String> readAllNames(DataSource dataSource) throws SQLException {
+        var result = new ArrayList<String>();
+        try (
+                Connection ds = dataSource.getConnection();
+                PreparedStatement ps = ds.prepareStatement("select name from MyTable");
+                ResultSet rslt = ps.executeQuery()
+        ) {
+            while(rslt.next()) {
+                result.add(rslt.getString(1));
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
The TestSqlAnnotationHandler tried to load a ResourceLoader bean even if there were no Sql annotations. This fails if the context has been stopped in the test.

This PR does 2 things:

1. It only tries to load the bean if it has work to do
2. If it has work to do, and the context is stopped, it logs a warning and skips processing the scripts

I believe master has already switched to the 4.4.0 micronaut release (next minor) so I attached it to that project