### PR TITLE
Update settingUpJUnit5.adoc

### DIFF
--- a/src/main/docs/guide/junit5/settingUpJUnit5.adoc
+++ b/src/main/docs/guide/junit5/settingUpJUnit5.adoc
@@ -30,4 +30,14 @@ Or for Maven:
     <artifactId>micronaut-test-junit5</artifactId>
     <scope>test</scope>
 </dependency>
+<dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-api</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-engine</artifactId>
+    <scope>test</scope>
+</dependency>
 ----


### PR DESCRIPTION
The documentation about testing with JUnit5 and Maven lacked dependencies that were clearly visible in the Gradle example.