### PR TITLE
Allow RestAssured to test external servers

### DIFF
--- a/test-rest-assured/src/main/java/io/micronaut/test/rest/assured/RequestSpecificationFactory.java
+++ b/test-rest-assured/src/main/java/io/micronaut/test/rest/assured/RequestSpecificationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,23 @@
 package io.micronaut.test.rest.assured;
 
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 
+import static io.micronaut.test.support.server.TestEmbeddedServer.PROPERTY;
+
 /**
  * Helper class making it easier to create request specifications.
  *
  * @author gkrocher
- * @since 3.4.0 
+ * @since 3.4.0
  */
 @Factory
-@Requires(beans = EmbeddedServer.class) 
+@Requires(beans = EmbeddedServer.class)
 public class RequestSpecificationFactory {
 
     /**
@@ -37,10 +40,20 @@ public class RequestSpecificationFactory {
      * @return A request specification for the current server.
      */
     @Prototype
-    @Requires(beans = EmbeddedServer.class) 
+    @Requires(beans = EmbeddedServer.class, missingProperty = PROPERTY)
     RequestSpecification requestSpecification(EmbeddedServer embeddedServer) {
         return RestAssured.given()
             .port(embeddedServer.getPort());
     }
 
+    /**
+     * @param url            The optional URL for an external service
+     * @return A request specification for the current server.
+     */
+    @Prototype
+    @Requires(property = PROPERTY)
+    RequestSpecification requestSpecificationWithURL(@Property(name = PROPERTY) String url) {
+        return RestAssured.given()
+            .baseUri(url);
+    }
 }

--- a/test-rest-assured/src/main/java/io/micronaut/test/rest/assured/RequestSpecificationFactory.java
+++ b/test-rest-assured/src/main/java/io/micronaut/test/rest/assured/RequestSpecificationFactory.java
@@ -47,8 +47,8 @@ public class RequestSpecificationFactory {
     }
 
     /**
-     * @param url            The optional URL for an external service
-     * @return A request specification for the current server.
+     * @param url The optional URL for an external service
+     * @return A request specification for the external server.
      */
     @Prototype
     @Requires(property = PROPERTY)

--- a/test-rest-assured/src/test/java/io/micronaut/test/rest/assured/RestAssuredExternalServerTest.java
+++ b/test-rest-assured/src/test/java/io/micronaut/test/rest/assured/RestAssuredExternalServerTest.java
@@ -1,0 +1,30 @@
+package io.micronaut.test.rest.assured;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+
+@MicronautTest
+@Property(name = "micronaut.test.server.url", value = "https://jsonplaceholder.typicode.com")
+class RestAssuredExternalServerTest {
+
+    @Test
+    void testSinglePost(RequestSpecification spec) {
+        spec
+            .when().get("/posts/1")
+            .then().statusCode(200)
+            .body("title", is("sunt aut facere repellat provident occaecati excepturi optio reprehenderit"));
+    }
+
+    @Test
+    void testUsers(RequestSpecification spec) {
+        spec
+            .when().get("/users")
+            .then().statusCode(200)
+            .body("id", hasSize(10));
+    }
+}

--- a/test-rest-assured/src/test/resources/logback.xml
+++ b/test-rest-assured/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
RestAssured testing was tied to the local EmbeddedServer.

This change allows setting `micronaut.test.server.url` to target an external server.

Closes #1006