### PR TITLE
Add type pollution test harness

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ managed-junit = "5.10.2"
 managed-rest-assured = "5.4.0"
 managed-kotest = "5.9.1"
 managed-spock = "2.3-groovy-4.0"
+managed-bytebuddy = "1.14.17"
 
 kotlin = "1.9.24"
 graal-svm = "23.1.3"
@@ -57,6 +58,9 @@ managed-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engin
 managed-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "managed-junit" }
 managed-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "managed-junit" }
 managed-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "managed-junit" }
+
+managed-bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "managed-bytebuddy" }
+managed-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "managed-bytebuddy" }
 
 # BOMs
 boms-junit = { module = "org.junit:junit-bom", version.ref = "managed-junit" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,3 +34,4 @@ include "test-kotest5"
 include "test-rest-assured"
 include 'test-suite-sql-r2dbc'
 include 'test-suite-at-sql-jpa'
+include 'test-type-pollution'

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -21,3 +21,10 @@ tasks.withType<Test> {
         enabled = false
     }
 }
+
+micronautBuild {
+    // todo: enable after 4.4.0
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("io.micronaut.build.internal.micronaut-test-module")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.managed.bytebuddy)
+
+    testImplementation(libs.managed.bytebuddy.agent)
+    testImplementation(libs.managed.junit.jupiter.api)
+    testRuntimeOnly(libs.managed.junit.jupiter.engine)
+}

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -13,3 +13,7 @@ dependencies {
     testImplementation(libs.managed.junit.jupiter.api)
     testRuntimeOnly(libs.managed.junit.jupiter.engine)
 }
+
+tasks.withType<Test> {
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+}

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -16,4 +16,8 @@ dependencies {
 
 tasks.withType<Test> {
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+
+    jacoco {
+        enabled = false
+    }
 }

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ClassSwitch.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ClassSwitch.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class dynamically builds and maintains a {@link MethodHandle} that calls any of a number of
+ * downstream {@link MethodHandle}s, depending on a {@link Class} parameter. If a new {@link Class}
+ * is passed to this {@link MethodHandle}, it is mutated to gain a branch for that {@link Class} to
+ * enable fast dispatch in the future.
+ */
+abstract class ClassSwitch {
+    private static final MethodHandle FALLBACK;
+    private static final MethodHandle CLASS_EQUALS;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            FALLBACK = lookup.findVirtual(ClassSwitch.class, "fallback", MethodType.methodType(void.class, Class.class));
+            CLASS_EQUALS = MethodHandles.explicitCastArguments(
+                lookup.findVirtual(Object.class, "equals", MethodType.methodType(boolean.class, Object.class)),
+                MethodType.methodType(boolean.class, Class.class, Class.class)
+            );
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final MutableCallSite callSite;
+    private final int switchPosition;
+
+    /**
+     * @param expectedType The type of the downstream method returned by {@link #downstream(Class)}
+     * @param switchPosition The index in the parameter list where the {@link Class} parameter
+     *                       should be added that this {@link ClassSwitch} will switch on
+     */
+    ClassSwitch(MethodType expectedType, int switchPosition) {
+        List<Class<?>> combinedArgs = new ArrayList<>(expectedType.parameterList());
+        combinedArgs.add(switchPosition, Class.class);
+        this.callSite = new MutableCallSite(
+            MethodHandles.dropArguments(
+                MethodHandles.throwException(expectedType.returnType(), UnsupportedOperationException.class).bindTo(new UnsupportedOperationException("Type not bound yet")),
+                0,
+                combinedArgs
+            )
+        );
+        this.switchPosition = switchPosition;
+
+        // replace the call site with a handle that first calls fallback and then calls the call
+        // site again. The fallback call will update the call site to include the new type.
+        callSite.setTarget(MethodHandles.foldArguments(
+            dynamicInvoker(),
+            switchPosition,
+            FALLBACK.bindTo(this)
+        ));
+    }
+
+    /**
+     * Build a {@link MethodHandle} that invokes this switch statement.
+     */
+    public final MethodHandle dynamicInvoker() {
+        return callSite.dynamicInvoker();
+    }
+
+    private synchronized void fallback(Class<?> cl) {
+        MethodHandle test = CLASS_EQUALS.bindTo(cl);
+        if (switchPosition != 0) {
+            test = MethodHandles.dropArguments(test, 0, callSite.getTarget().type().parameterList().subList(0, switchPosition));
+        }
+        callSite.setTarget(MethodHandles.guardWithTest(
+            test,
+            MethodHandles.dropArguments(downstream(cl), switchPosition, List.of(Class.class)),
+            callSite.getTarget()
+        ));
+    }
+
+    /**
+     * Construct a new downstream {@link MethodHandle} for the given type.
+     *
+     * @param cl The type that was passed to this switch statement
+     * @return The method handle that will be called every time this type is seen
+     */
+    protected abstract MethodHandle downstream(Class<?> cl);
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ConcreteCounter.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ConcreteCounter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import io.micronaut.core.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+/**
+ * This class recognizes the "focus changes" that are then forwarded to the {@link FocusListener}.
+ * <p>
+ * There is one {@link ConcreteCounter} for each concrete type. Each {@link ConcreteCounter} has an
+ * {@link InterfaceHolder} for any interfaces that the concrete type is type checked against. Each
+ * {@link InterfaceHolder} has a {@link MutableCallSite}. For the interface that was last type
+ * checked, this call site does nothing. For any other interface, a type check leads to a "focus
+ * event": The event is forwarded to the {@link FocusListener} for logging. The now-focused
+ * interface changes its call site to do nothing, and the previously focused interface becomes
+ * unfocused.
+ */
+final class ConcreteCounter {
+    static final ClassValue<ConcreteCounter> COUNTERS = new ClassValue<>() {
+        @Override
+        protected ConcreteCounter computeValue(Class<?> type) {
+            return new ConcreteCounter(type);
+        }
+    };
+
+    @Nullable
+    static FocusListener focusListener;
+
+    private static final MethodHandle FOCUS;
+    private static final MethodHandle IGNORE = MethodHandles.empty(MethodType.methodType(void.class));
+
+    static {
+        try {
+            FOCUS = MethodHandles.lookup()
+                .findVirtual(InterfaceHolder.class, "focus", MethodType.methodType(void.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final Class<?> concreteType;
+
+    private final ClassValue<InterfaceHolder> holdersByInterface = new ClassValue<>() {
+        @Override
+        protected InterfaceHolder computeValue(Class<?> type) {
+            return new InterfaceHolder(type);
+        }
+    };
+    private InterfaceHolder focused = null;
+
+    private ConcreteCounter(Class<?> concreteType) {
+        this.concreteType = concreteType;
+    }
+
+    MethodHandle typeCheckHandle(Class<?> interfaceType) {
+        return holdersByInterface.get(interfaceType).callSite.dynamicInvoker();
+    }
+
+    final class InterfaceHolder {
+        final Class<?> interfaceType;
+        final MethodHandle focus = FOCUS.bindTo(this);
+        final MutableCallSite callSite = new MutableCallSite(focus);
+
+        InterfaceHolder(Class<?> interfaceType) {
+            this.interfaceType = interfaceType;
+        }
+
+        private void unfocus() {
+            assert Thread.holdsLock(ConcreteCounter.this);
+            callSite.setTarget(focus);
+        }
+
+        private void focus() {
+            FocusListener focusListener = ConcreteCounter.focusListener;
+            if (focusListener != null) {
+                focusListener.onFocus(concreteType, interfaceType);
+            }
+            synchronized (ConcreteCounter.this) {
+                if (focused != null) {
+                    focused.unfocus();
+                }
+                focused = this;
+                callSite.setTarget(IGNORE);
+            }
+        }
+    }
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/FocusListener.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/FocusListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Public listener for responding to focus events.<p>
+ * A focus event happens when a certain concrete type is successfully type checked against an
+ * interface that it was not checked against immediately before:
+ * <code><pre>
+ * Impl impl = new Impl();
+ * impl instanceof A // focus event
+ * impl instanceof A // no focus event
+ * impl instanceof A // no focus event
+ * impl instanceof B // focus event
+ * impl instanceof B // no focus event
+ * impl instanceof A // focus event
+ * </pre></code>
+ * Each focus event may invalidate a cache field on the concrete class which can be especially
+ * expensive on machines with many cores (JDK-8180450). Thus, such focus events should be kept off
+ * the hot path when running on JDK versions that still have this bug.
+ */
+public interface FocusListener {
+    /**
+     * Set the global focus listener, or {@code null} to disable listening for focus events.
+     *
+     * @param focusListener The focus listener
+     */
+    static void setFocusListener(@Nullable FocusListener focusListener) {
+        ConcreteCounter.focusListener = focusListener;
+    }
+
+    /**
+     * Called on every focus event, potentially concurrently.
+     *
+     * @param concreteType  The concrete type that was checked
+     * @param interfaceType The interface type that the concrete type was type checked against
+     */
+    void onFocus(Class<?> concreteType, Class<?> interfaceType);
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/HookBootstrap.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/HookBootstrap.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+/**
+ * Method handle bootstrap used by generated code to call into the {@link ConcreteCounter}. Must be
+ * public for generated code, but should never be used directly.
+ */
+@SuppressWarnings("unused")
+@Internal
+public final class HookBootstrap {
+    static final Method METHOD_STATIC_TYPE_CHECK;
+    static final Method METHOD_DYNAMIC_TYPE_CHECK;
+    static final Method METHOD_DYNAMIC_TYPE_CHECK_CAST;
+
+    static {
+        try {
+            METHOD_STATIC_TYPE_CHECK = HookBootstrap.class.getDeclaredMethod("staticTypeCheck", MethodHandles.Lookup.class, String.class, MethodType.class, Class.class);
+            METHOD_DYNAMIC_TYPE_CHECK = HookBootstrap.class.getDeclaredMethod("dynamicTypeCheck", MethodHandles.Lookup.class, String.class, MethodType.class);
+            METHOD_DYNAMIC_TYPE_CHECK_CAST = HookBootstrap.class.getDeclaredMethod("dynamicTypeCheckCast", MethodHandles.Lookup.class, String.class, MethodType.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HookBootstrap() {
+    }
+
+    /**
+     * Called on successful type check in scenarios where the interface type is statically known,
+     * i.e. checkcast and instanceof instructions. Returned method type is
+     * {@code (Ljava/lang/Object;)V}, where the sole parameter is the object that was type checked.
+     *
+     * @param lookup        Required bootstrap method parameter
+     * @param name          Required bootstrap method parameter
+     * @param type          Required bootstrap method parameter
+     * @param interfaceType The statically known interface type
+     * @return {@code (Ljava/lang/Object;)V}
+     */
+    public static CallSite staticTypeCheck(MethodHandles.Lookup lookup, String name, MethodType type, Class<?> interfaceType) throws NoSuchMethodException, IllegalAccessException {
+        if (!interfaceType.isInterface()) {
+            // for non-interface types, do nothing
+            return new ConstantCallSite(MethodHandles.empty(type));
+        }
+
+        return new ConstantCallSite(MethodHandles.collectArguments(
+            new ClassSwitch(MethodType.methodType(void.class), 0) {
+                @Override
+                protected MethodHandle downstream(Class<?> concreteType) {
+                    return ConcreteCounter.COUNTERS.get(concreteType).typeCheckHandle(interfaceType);
+                }
+            }.dynamicInvoker(),
+            0,
+            lookup.findVirtual(Object.class, "getClass", MethodType.methodType(Class.class))
+        ));
+    }
+
+    /**
+     * Called on successful type check in scenarios where the interface type is not statically
+     * known, i.e. {@link Class#isAssignableFrom(Class)} and {@link Class#isInstance(Object)} calls.
+     * Returned method type is {@code (Ljava/lang/Class;Ljava/lang/Class;)V}, where the first
+     * parameter is the interface type and the second parameter is the concrete type.
+     *
+     * @param lookup        Required bootstrap method parameter
+     * @param name          Required bootstrap method parameter
+     * @param type          Required bootstrap method parameter
+     * @return {@code (Ljava/lang/Class;Ljava/lang/Class;)V}
+     */
+    public static CallSite dynamicTypeCheck(MethodHandles.Lookup lookup, String name, MethodType type) throws NoSuchMethodException, IllegalAccessException {
+        return new ConstantCallSite(dynamicTypeCheckImpl(lookup));
+    }
+
+    /**
+     * Called on successful type check for {@link Class#cast(Object)}. This is a slightly modified
+     * {@link #dynamicTypeCheck} to make the cast implementation work without local variables.
+     * Returned method type is {@code (Ljava/lang/Class;Ljava/lang/Object;)Ljava/lang/Object;},
+     * where the first parameter is the interface type and the second parameter is the concrete
+     * value that was cast. The return value is the second parameter.
+     *
+     * @param lookup        Required bootstrap method parameter
+     * @param name          Required bootstrap method parameter
+     * @param type          Required bootstrap method parameter
+     * @return {@code (Ljava/lang/Class;Ljava/lang/Object;)Ljava/lang/Object;}
+     */
+    public static CallSite dynamicTypeCheckCast(MethodHandles.Lookup lookup, String name, MethodType type) throws NoSuchMethodException, IllegalAccessException {
+        return new ConstantCallSite(MethodHandles.foldArguments(
+            MethodHandles.dropArguments(MethodHandles.identity(Object.class), 0, Class.class),
+            MethodHandles.collectArguments(
+                dynamicTypeCheckImpl(lookup),
+                1,
+                lookup.findVirtual(Object.class, "getClass", MethodType.methodType(Class.class))
+            )
+        ));
+    }
+
+    private static MethodHandle dynamicTypeCheckImpl(MethodHandles.Lookup lookup) throws NoSuchMethodException, IllegalAccessException {
+        MethodHandle switcher = new ClassSwitch(MethodType.methodType(void.class, Class.class), 0) {
+            @Override
+            protected MethodHandle downstream(Class<?> interfaceType) {
+                return new ClassSwitch(MethodType.methodType(void.class), 0) {
+                    @Override
+                    protected MethodHandle downstream(Class<?> concreteType) {
+                        return ConcreteCounter.COUNTERS.get(concreteType).typeCheckHandle(interfaceType);
+                    }
+                }.dynamicInvoker();
+            }
+        }.dynamicInvoker();
+        return MethodHandles.guardWithTest(
+            lookup.findVirtual(Class.class, "isInterface", MethodType.methodType(boolean.class)),
+            switcher,
+            MethodHandles.empty(MethodType.methodType(void.class, Class.class, Class.class))
+        );
+    }
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ThresholdFocusListener.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ThresholdFocusListener.java
@@ -45,6 +45,10 @@ public final class ThresholdFocusListener implements FocusListener {
      * @return {@code false} iff any concrete class was type checked too often
      */
     public boolean checkThresholds(long threshold) {
+        if (trackers.isEmpty() || trackers.values().stream().noneMatch(c -> c.total.sum() > 0)) {
+            throw new IllegalStateException("No focus events received. Are the hooks installed correctly?");
+        }
+
         boolean failed = false;
         for (ConcreteTracker concrete : trackers.values()) {
             long sum = concrete.total.sum();

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ThresholdFocusListener.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/ThresholdFocusListener.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * {@link FocusListener} implementation that counts and tracks all focus events, including stack
+ * traces. At the end of the test, {@link #checkThresholds(long)} can be used to verify that no
+ * concrete class exceeded a given focus event threshold.
+ */
+public final class ThresholdFocusListener implements FocusListener {
+    private static final StackWalker WALKER = StackWalker.getInstance(Set.of(StackWalker.Option.SHOW_REFLECT_FRAMES, StackWalker.Option.RETAIN_CLASS_REFERENCE));
+
+    private final Map<Class<?>, ConcreteTracker> trackers = new ConcurrentHashMap<>();
+
+    @Override
+    public void onFocus(Class<?> concreteType, Class<?> interfaceType) {
+        trackers.computeIfAbsent(concreteType, ConcreteTracker::new).onFocus(interfaceType);
+    }
+
+    /**
+     * Check whether the number of focus events exceeded the given threshold for any concrete
+     * class. If this is the case, this method also prints a human-readable report on all type
+     * checking stack traces for the concrete type to {@code System.out}.
+     *
+     * @param threshold The number of events that should not be exceeded
+     * @return {@code false} iff any concrete class was type checked too often
+     */
+    public boolean checkThresholds(long threshold) {
+        boolean failed = false;
+        for (ConcreteTracker concrete : trackers.values()) {
+            long sum = concrete.total.sum();
+            if (sum >= threshold) {
+                failed = true;
+                System.out.println("Concrete type: " + concrete.concreteType.getName() + " (" + sum + " hits)");
+                for (InterfaceTracker itf : concrete.interfaces.values()) {
+                    System.out.println("  Interface type: " + itf.interfaceType.getName());
+                    itf.counts.entrySet().stream()
+                        .sorted(Comparator.<Map.Entry<?, Long>>comparingLong(Map.Entry::getValue).reversed())
+                        .forEach(e -> {
+                            System.out.println("    Stack: (" + e.getValue() + " hits)");
+                            for (StackTraceElement element : itf.stacks.get(e.getKey())) {
+                                System.out.println("      " + element.toString());
+                            }
+                        });
+                }
+            }
+        }
+        return !failed;
+    }
+
+    private static final class ConcreteTracker {
+        private final Class<?> concreteType;
+        private final Map<Class<?>, InterfaceTracker> interfaces = new ConcurrentHashMap<>();
+        private final LongAdder total = new LongAdder();
+
+        ConcreteTracker(Class<?> concreteType) {
+            this.concreteType = concreteType;
+        }
+
+        void onFocus(Class<?> interfaceType) {
+            total.increment();
+            interfaces.computeIfAbsent(interfaceType, InterfaceTracker::new).onFocus();
+        }
+    }
+
+    private static final class InterfaceTracker {
+        private final Class<?> interfaceType;
+        private final Map<Long, Long> counts = new ConcurrentHashMap<>();
+        private final Map<Long, StackTraceElement[]> stacks = new ConcurrentHashMap<>();
+
+        InterfaceTracker(Class<?> interfaceType) {
+            this.interfaceType = interfaceType;
+        }
+
+        void onFocus() {
+            Long hash = WALKER.walk(s -> s.mapToLong(sf -> sf.getDeclaringClass().hashCode() * 31L * 31 + sf.getMethodName().hashCode() * 31L + sf.getMethodType().hashCode())
+                .reduce(0, (a, b) -> a * 31 + b));
+            if (counts.compute(hash, (k, oldV) -> oldV == null ? 1L : Math.incrementExact(oldV)) == 1L) {
+                stacks.put(hash, WALKER.walk(s ->
+                    // InterfaceHolder.focus is the first stack frame in the focus chain
+                    s.dropWhile(f -> f.getDeclaringClass() != ConcreteCounter.InterfaceHolder.class)
+                        .skip(1) // skip the InterfaceHolder itself
+                        .map(StackWalker.StackFrame::toStackTraceElement)
+                        .toArray(StackTraceElement[]::new)));
+            }
+        }
+    }
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.test.typepollution;
 
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.TypeConstantAdjustment;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.utility.JavaModule;
 
@@ -64,9 +66,11 @@ public final class TypePollutionTransformer implements AgentBuilder.Transformer 
      */
     public static void install(Instrumentation instrumentation) {
         new AgentBuilder.Default()
+            .with(new ByteBuddy().with(TypeValidation.DISABLED))
             .with(AgentBuilder.Listener.StreamWriting.toSystemError().withErrorsOnly())
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(AgentBuilder.LambdaInstrumentationStrategy.DISABLED)
+            .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
             .with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
             .type(ElementMatchers.any()
                 .and(ElementMatchers.not(ElementMatchers.nameStartsWith("net.bytebuddy.")))

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
@@ -20,6 +20,7 @@ import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.TypeConstantAdjustment;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.InstrumentedType;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.utility.JavaModule;
@@ -66,7 +67,9 @@ public final class TypePollutionTransformer implements AgentBuilder.Transformer 
      */
     public static void install(Instrumentation instrumentation) {
         new AgentBuilder.Default()
-            .with(new ByteBuddy().with(TypeValidation.DISABLED))
+            .with(new ByteBuddy()
+                .with(TypeValidation.DISABLED)
+                .with(InstrumentedType.Factory.Default.FROZEN))
             .with(AgentBuilder.Listener.StreamWriting.toSystemError().withErrorsOnly())
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(AgentBuilder.LambdaInstrumentationStrategy.DISABLED)

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.TypeConstantAdjustment;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.matcher.ElementMatchers;
+import net.bytebuddy.utility.JavaModule;
+
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+/**
+ * {@link AgentBuilder.Transformer} implementation that installs the necessary hooks to call into
+ * the {@link FocusListener}.
+ */
+public final class TypePollutionTransformer implements AgentBuilder.Transformer {
+    private TypePollutionTransformer() {
+    }
+
+    /**
+     * Create a new instance of this transformer.
+     *
+     * @return The instance
+     */
+    public static AgentBuilder.Transformer create() {
+        return new TypePollutionTransformer();
+    }
+
+    @Override
+    public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule module, ProtectionDomain protectionDomain) {
+        if (classLoader != null) {
+            try {
+                classLoader.loadClass(HookBootstrap.class.getName());
+            } catch (ClassNotFoundException e) {
+                return builder;
+            }
+        }
+
+        return builder
+            .visit(TypeConstantAdjustment.INSTANCE)
+            .visit(new VisitorWrapperImpl());
+    }
+
+    /**
+     * Install this transformer into the given {@link Instrumentation}.
+     *
+     * @param instrumentation The instrumentation used for modifying classes
+     */
+    public static void install(Instrumentation instrumentation) {
+        new AgentBuilder.Default()
+            .with(AgentBuilder.Listener.StreamWriting.toSystemError().withErrorsOnly())
+            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(AgentBuilder.LambdaInstrumentationStrategy.DISABLED)
+            .with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
+            .type(ElementMatchers.any()
+                .and(ElementMatchers.not(ElementMatchers.nameStartsWith("net.bytebuddy.")))
+                .and(ElementMatchers.not(ElementMatchers.nameStartsWith("com.sun")))
+                .and(ElementMatchers.not(ElementMatchers.nameStartsWith(TypePollutionTransformer.class.getPackageName())))
+            )
+            .transform(create())
+            .installOn(instrumentation);
+    }
+}

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/VisitorWrapperImpl.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/VisitorWrapperImpl.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.typepollution;
+
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.Handle;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.jar.asm.Type;
+import net.bytebuddy.pool.TypePool;
+
+import java.lang.reflect.Method;
+
+final class VisitorWrapperImpl extends AsmVisitorWrapper.AbstractBase {
+    @Override
+    public int mergeWriter(int flags) {
+        return flags | ClassWriter.COMPUTE_FRAMES;
+    }
+
+    @Override
+    public ClassVisitor wrap(TypeDescription instrumentedType, ClassVisitor classVisitor, Implementation.Context implementationContext, TypePool typePool, FieldList<FieldDescription.InDefinedShape> fields, MethodList<?> methods, int writerFlags, int readerFlags) {
+        return new ClassVisitorImpl(Opcodes.ASM9, classVisitor);
+    }
+
+    private static final class ClassVisitorImpl extends ClassVisitor {
+        ClassVisitorImpl(int api, ClassVisitor classVisitor) {
+            super(api, classVisitor);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            super.visit(Math.max(version, Opcodes.V1_8), access, name, signature, superName, interfaces);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            return new MethodVisitorImpl(Opcodes.ASM9, super.visitMethod(access, name, descriptor, signature, exceptions));
+        }
+    }
+
+    private static final class MethodVisitorImpl extends MethodVisitor {
+        MethodVisitorImpl(int api, MethodVisitor methodVisitor) {
+            super(api, methodVisitor);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            if (opcode == Opcodes.INVOKEVIRTUAL && owner.equals(Type.getInternalName(Class.class))) {
+                if (name.equals("cast")) {
+                    // itf ref
+                    super.visitInsn(Opcodes.DUP2);
+                    // itf ref itf ref
+                    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    Label skip = new Label();
+                    Label end = new Label();
+                    // itf ref ref
+                    super.visitJumpInsn(Opcodes.IFNULL, skip);
+                    // itf ref
+                    indy(HookBootstrap.METHOD_DYNAMIC_TYPE_CHECK_CAST, Type.getMethodDescriptor(Type.getType(Object.class), Type.getType(Class.class), Type.getType(Object.class)));
+                    // ref
+                    super.visitJumpInsn(Opcodes.GOTO, end);
+
+                    super.visitLabel(skip);
+                    // itf ref
+                    super.visitInsn(Opcodes.SWAP);
+                    // ref itf
+                    super.visitInsn(Opcodes.POP);
+                    // ref
+                    super.visitLabel(end);
+                    //
+                } else if (name.equals("isInstance")) {
+                    // itf ref
+                    super.visitInsn(Opcodes.DUP2);
+                    // itf ref itf ref
+                    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    // itf ref boolean
+                    Label skip = new Label();
+                    Label end = new Label();
+                    super.visitJumpInsn(Opcodes.IFEQ, skip);
+                    // itf ref
+                    invokeGetClass();
+                    // itf concrete
+                    dynamicTypeCheckSucceeded();
+                    //
+                    super.visitInsn(Opcodes.ICONST_1);
+                    // boolean
+                    super.visitJumpInsn(Opcodes.GOTO, end);
+
+                    super.visitLabel(skip);
+                    // itf ref
+                    super.visitInsn(Opcodes.POP2);
+                    //
+                    super.visitInsn(Opcodes.ICONST_0);
+                    // boolean
+                    super.visitLabel(end);
+                    // boolean
+                } else if (name.equals("isAssignableFrom")) {
+                    // itf concrete
+                    super.visitInsn(Opcodes.DUP2);
+                    // itf concrete itf concrete
+                    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    // itf concrete boolean
+                    Label skip = new Label();
+                    Label end = new Label();
+                    super.visitJumpInsn(Opcodes.IFEQ, skip);
+                    // itf concrete
+                    dynamicTypeCheckSucceeded();
+                    //
+                    super.visitInsn(Opcodes.ICONST_1);
+                    // boolean
+                    super.visitJumpInsn(Opcodes.GOTO, end);
+
+                    super.visitLabel(skip);
+                    // itf concrete
+                    super.visitInsn(Opcodes.POP2);
+                    //
+                    super.visitInsn(Opcodes.ICONST_0);
+                    // boolean
+                    super.visitLabel(end);
+                    // boolean
+                } else {
+                    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                }
+            } else {
+                super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+            }
+        }
+
+        private void invokeGetClass() {
+            super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(Object.class), "getClass", Type.getMethodDescriptor(Type.getType(Class.class)), false);
+        }
+
+        private void dynamicTypeCheckSucceeded() {
+            indy(HookBootstrap.METHOD_DYNAMIC_TYPE_CHECK, Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Class.class), Type.getType(Class.class)));
+        }
+
+        @Override
+        public void visitTypeInsn(int opcode, String type) {
+            // line comments show the current stack
+            if (opcode == Opcodes.INSTANCEOF) {
+                // ref
+                super.visitInsn(Opcodes.DUP);
+                // ref ref
+                super.visitTypeInsn(opcode, type);
+                // ref boolean
+                Label skip = new Label();
+                Label end = new Label();
+                super.visitJumpInsn(Opcodes.IFEQ, skip);
+                // ref
+                staticTypeCheckSucceeded(type);
+                //
+                super.visitInsn(Opcodes.ICONST_1);
+                // boolean
+                super.visitJumpInsn(Opcodes.GOTO, end);
+
+                super.visitLabel(skip);
+                // ref
+                super.visitInsn(Opcodes.POP);
+                //
+                super.visitInsn(Opcodes.ICONST_0);
+                // boolean
+                super.visitLabel(end);
+            } else if (opcode == Opcodes.CHECKCAST) {
+                // ref
+                super.visitTypeInsn(opcode, type);
+                // ref
+                super.visitInsn(Opcodes.DUP);
+                // ref ref
+                Label skip = new Label();
+                super.visitJumpInsn(Opcodes.IFNULL, skip);
+                // ref
+                super.visitInsn(Opcodes.DUP);
+                // ref ref
+                staticTypeCheckSucceeded(type);
+                // ref
+                super.visitLabel(skip);
+                // ref
+            } else {
+                super.visitTypeInsn(opcode, type);
+            }
+        }
+
+        private void staticTypeCheckSucceeded(String type) {
+            indy(HookBootstrap.METHOD_STATIC_TYPE_CHECK, Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object.class)), Type.getObjectType(type));
+        }
+
+        private void indy(Method bootstrapMethod, String callSiteDescriptor, Object... args) {
+            super.visitInvokeDynamicInsn(
+                "foo",
+                callSiteDescriptor,
+                new Handle(
+                    Opcodes.H_INVOKESTATIC,
+                    Type.getInternalName(bootstrapMethod.getDeclaringClass()),
+                    bootstrapMethod.getName(),
+                    Type.getMethodDescriptor(bootstrapMethod),
+                    false
+                ),
+                args
+            );
+        }
+    }
+}

--- a/test-type-pollution/src/test/java/io/micronaut/test/typepollution/ThresholdFocusListenerTest.java
+++ b/test-type-pollution/src/test/java/io/micronaut/test/typepollution/ThresholdFocusListenerTest.java
@@ -1,0 +1,55 @@
+package io.micronaut.test.typepollution;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ThresholdFocusListenerTest {
+    @BeforeAll
+    static void setup() {
+        ByteBuddyAgent.install();
+        VisitorWrapperImplTest.hook(FlipFlop.class);
+    }
+
+    @Test
+    void belowThreshold() {
+        ThresholdFocusListener listener = new ThresholdFocusListener();
+        FocusListener.setFocusListener(listener);
+
+        FlipFlop flipFlop = new FlipFlop();
+        for (int i = 0; i < 200; i++) {
+            flipFlop.flipFlop(new Impl());
+        }
+
+        Assertions.assertTrue(listener.checkThresholds(1000));
+    }
+
+    @Test
+    void aboveThreshold() {
+        ThresholdFocusListener listener = new ThresholdFocusListener();
+        FocusListener.setFocusListener(listener);
+
+        FlipFlop flipFlop = new FlipFlop();
+        for (int i = 0; i < 1000; i++) {
+            flipFlop.flipFlop(new Impl());
+        }
+
+        Assertions.assertFalse(listener.checkThresholds(1000));
+    }
+
+    private interface A {
+    }
+
+    private interface B {
+    }
+
+    private static final class Impl implements A, B {
+    }
+
+    private static class FlipFlop {
+        boolean flipFlop(Object o) {
+            return (o instanceof A) ^ (o instanceof B);
+        }
+    }
+}

--- a/test-type-pollution/src/test/java/io/micronaut/test/typepollution/VisitorWrapperImplTest.java
+++ b/test-type-pollution/src/test/java/io/micronaut/test/typepollution/VisitorWrapperImplTest.java
@@ -1,0 +1,340 @@
+package io.micronaut.test.typepollution;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassReloadingStrategy;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings({"ResultOfMethodCallIgnored", "ConstantValue", "UnusedReturnValue", "SameParameterValue"})
+class VisitorWrapperImplTest {
+    @BeforeAll
+    static void setup() {
+        ByteBuddyAgent.install();
+
+        hook(Reset.class);
+    }
+
+    static void hook(Class<?> cl) {
+        try (DynamicType.Unloaded<?> unloaded = new ByteBuddy()
+            .redefine(cl)
+            .visit(new VisitorWrapperImpl())
+            .make()) {
+
+            unloaded.load(cl.getClassLoader(), ClassReloadingStrategy.fromInstalledAgent());
+        }
+    }
+
+    @BeforeEach
+    void reset() {
+        new Reset().reset(new Impl());
+    }
+
+    @Test
+    public void checkCast() {
+        hook(CheckCast.class);
+
+        TrackingFocusListener listener = new TrackingFocusListener().install();
+
+        CheckCast cl = new CheckCast();
+
+        cl.a(new Impl());
+        cl.a(new Impl());
+
+        cl.b(new Impl());
+        cl.b(new Impl());
+        cl.b(new Impl());
+
+        cl.a(new Impl());
+
+        cl.a(null);
+        try {
+            cl.a(1);
+            Assertions.fail();
+        } catch (ClassCastException ignored) {
+            // expected
+        }
+
+        cl.concrete(new Impl());
+
+        List<Entry> entries = listener.uninstall();
+        Assertions.assertEquals(
+            List.of(
+                new Entry(Impl.class, A.class),
+                new Entry(Impl.class, B.class),
+                new Entry(Impl.class, A.class)
+            ),
+            entries
+        );
+    }
+
+    @Test
+    public void instanceOf() {
+        hook(InstanceOf.class);
+
+        TrackingFocusListener listener = new TrackingFocusListener().install();
+
+        InstanceOf cl = new InstanceOf();
+
+        Assertions.assertTrue(cl.a(new Impl()));
+        Assertions.assertTrue(cl.a(new Impl()));
+
+        Assertions.assertTrue(cl.b(new Impl()));
+        Assertions.assertTrue(cl.b(new Impl()));
+        Assertions.assertTrue(cl.b(new Impl()));
+
+        Assertions.assertTrue(cl.a(new Impl()));
+
+        Assertions.assertFalse(cl.a(null));
+        Assertions.assertFalse(cl.a(1));
+
+        Assertions.assertTrue(cl.concrete(new Impl()));
+
+        List<Entry> entries = listener.uninstall();
+        Assertions.assertEquals(
+            List.of(
+                new Entry(Impl.class, A.class),
+                new Entry(Impl.class, B.class),
+                new Entry(Impl.class, A.class)
+            ),
+            entries
+        );
+    }
+
+    @Test
+    public void reflIsInstance() {
+        hook(ReflIsInstance.class);
+
+        TrackingFocusListener listener = new TrackingFocusListener().install();
+
+        ReflIsInstance cl = new ReflIsInstance();
+
+        Assertions.assertTrue(cl.a(new Impl()));
+        Assertions.assertTrue(cl.a(new Impl()));
+
+        Assertions.assertTrue(cl.b(new Impl()));
+        Assertions.assertTrue(cl.b(new Impl()));
+        Assertions.assertTrue(cl.b(new Impl()));
+
+        Assertions.assertTrue(cl.a(new Impl()));
+
+        Assertions.assertFalse(cl.a(null));
+        Assertions.assertFalse(cl.a(1));
+
+        Assertions.assertTrue(cl.concrete(new Impl()));
+
+        List<Entry> entries = listener.uninstall();
+        Assertions.assertEquals(
+            List.of(
+                new Entry(Impl.class, A.class),
+                new Entry(Impl.class, B.class),
+                new Entry(Impl.class, A.class)
+            ),
+            entries
+        );
+    }
+
+    @Test
+    public void reflCast() {
+        hook(ReflCast.class);
+
+        TrackingFocusListener listener = new TrackingFocusListener().install();
+
+        ReflCast cl = new ReflCast();
+
+        cl.a(new Impl());
+        cl.a(new Impl());
+
+        cl.b(new Impl());
+        cl.b(new Impl());
+        cl.b(new Impl());
+
+        cl.a(new Impl());
+
+        cl.a(null);
+        try {
+            cl.a(1);
+            Assertions.fail();
+        } catch (ClassCastException ignored) {
+            // expected
+        }
+
+        cl.concrete(new Impl());
+
+        List<Entry> entries = listener.uninstall();
+        Assertions.assertEquals(
+            List.of(
+                new Entry(Impl.class, A.class),
+                new Entry(Impl.class, B.class),
+                new Entry(Impl.class, A.class)
+            ),
+            entries
+        );
+    }
+
+    @Test
+    public void reflIsAssignableFrom() {
+        hook(ReflIsAssignableFrom.class);
+
+        TrackingFocusListener listener = new TrackingFocusListener().install();
+
+        ReflIsAssignableFrom cl = new ReflIsAssignableFrom();
+
+        Assertions.assertTrue(cl.a(Impl.class));
+        Assertions.assertTrue(cl.a(Impl.class));
+
+        Assertions.assertTrue(cl.b(Impl.class));
+        Assertions.assertTrue(cl.b(Impl.class));
+        Assertions.assertTrue(cl.b(Impl.class));
+
+        Assertions.assertTrue(cl.a(Impl.class));
+
+        Assertions.assertFalse(cl.a(Object.class));
+        Assertions.assertFalse(cl.a(int.class));
+
+        Assertions.assertTrue(cl.concrete(Impl.class));
+
+        List<Entry> entries = listener.uninstall();
+        Assertions.assertEquals(
+            List.of(
+                new Entry(Impl.class, A.class),
+                new Entry(Impl.class, B.class),
+                new Entry(Impl.class, A.class)
+            ),
+            entries
+        );
+    }
+
+    private interface A {
+    }
+
+    private interface B {
+    }
+
+    private interface ResetItf {
+    }
+
+    private static final class Impl implements A, B, ResetItf {
+    }
+
+    static final class TrackingFocusListener implements FocusListener {
+        private final List<Entry> entries = new ArrayList<>();
+
+        @Override
+        public synchronized void onFocus(Class<?> concreteType, Class<?> interfaceType) {
+            entries.add(new Entry(concreteType, interfaceType));
+        }
+
+        TrackingFocusListener install() {
+            FocusListener.setFocusListener(this);
+            return this;
+        }
+
+        List<Entry> uninstall() {
+            FocusListener.setFocusListener(null);
+            return entries;
+        }
+    }
+
+    record Entry(Class<?> concreteType, Class<?> interfaceType) {
+        @Override
+        public String toString() {
+            // simple name is a bit nicer
+            return "Entry[concreteType=" + concreteType.getSimpleName() + ", interfaceType=" + interfaceType.getSimpleName() + "]";
+        }
+    }
+
+    static final class Reset {
+        boolean reset(Object o) {
+            return o instanceof ResetItf;
+        }
+    }
+
+    static final class CheckCast {
+        A a(Object o) {
+            return (A) o;
+        }
+
+        B b(Object o) {
+            return (B) o;
+        }
+
+        Impl concrete(Object o) {
+            return (Impl) o;
+        }
+    }
+
+    static final class InstanceOf {
+        boolean a(Object o) {
+            return o instanceof A;
+        }
+
+        boolean b(Object o) {
+            return o instanceof B;
+        }
+
+        boolean concrete(Object o) {
+            return o instanceof Impl;
+        }
+    }
+
+    static final class ReflIsInstance {
+        private final Class<?> a = A.class;
+        private final Class<?> b = B.class;
+        private final Class<?> impl = Impl.class;
+
+        boolean a(Object o) {
+            return a.isInstance(o);
+        }
+
+        boolean b(Object o) {
+            return b.isInstance(o);
+        }
+
+        boolean concrete(Object o) {
+            return impl.isInstance(o);
+        }
+    }
+
+    static final class ReflCast {
+        private final Class<A> a = A.class;
+        private final Class<B> b = B.class;
+        private final Class<Impl> impl = Impl.class;
+
+        Object a(Object o) {
+            return a.cast(o);
+        }
+
+        Object b(Object o) {
+            return b.cast(o);
+        }
+
+        Object concrete(Object o) {
+            return impl.cast(o);
+        }
+    }
+
+    static final class ReflIsAssignableFrom {
+        private final Class<?> a = A.class;
+        private final Class<?> b = B.class;
+        private final Class<?> impl = Impl.class;
+
+        boolean a(Class<?> cl) {
+            return a.isAssignableFrom(cl);
+        }
+
+        boolean b(Class<?> cl) {
+            return b.isAssignableFrom(cl);
+        }
+
+        boolean concrete(Class<?> cl) {
+            return impl.isAssignableFrom(cl);
+        }
+    }
+}


### PR DESCRIPTION
Add a test harness that can be used to check for type pollution issues. Heavily inspired by and similar to https://github.com/RedHatPerf/type-pollution-agent . Key differences are:

- Works with in-VM ByteBuddyAgent. This makes installation somewhat easier in tests
- Fully programmatic API, to make threshold verification work without parsing summary reports. Also means this cannot be used for existing applications, it needs app code that explicitly listens to events
- indy-based implementation instead of invokestatic
- Less focus on performance, this is for testing only
- No type check miss support