### PR TITLE
Fix incorrect description of transaction modes in the docs.

### DIFF
--- a/src/main/docs/guide/includes/transaction.adoc
+++ b/src/main/docs/guide/includes/transaction.adoc
@@ -1,7 +1,4 @@
-By default, if `org.springframework:spring-tx` is in the test classpath (e.g. transitively via
-`io.micronaut.configuration:micronaut-hibernate-jpa-spring`), when using `@MicronautTest`, each `@Test` method will be
-wrapped in a transaction that will be rolled back when the test finishes. This behaviour can be changed by using the
-`transactional` and `rollback` properties.
+When using `@MicronautTest` each `@Test` method will be wrapped in a transaction that will be rolled back when the test finishes. This behaviour can be changed by using the `transactional` and `rollback` properties.
 
 To avoid creating a transaction:
 


### PR DESCRIPTION
In fact, the default is always true regardless of whether spring-tx is on the classpath or not.

Fixes #1057 