### PR TITLE
Instrument synthetic classes for type pollution as well

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,8 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true
 
+micronaut.jacoco.enabled=false
+
 kotlin.daemon.jvmargs=--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED\
  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,7 @@ restassuredtests=test-rest-assured/src/test/java/io/micronaut/test/rest/assured
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g
-
-micronaut.jacoco.enabled=false
+org.gradle.parallel=true
 
 kotlin.daemon.jvmargs=--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED\
  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ restassuredtests=test-rest-assured/src/test/java/io/micronaut/test/rest/assured
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g
-org.gradle.parallel=true
 
 micronaut.jacoco.enabled=false
 

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
 tasks.withType<Test> {
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+
+    extensions.findByType(JacocoTaskExtension::class)?.isEnabled = false
 }
 
 micronautBuild {

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -16,10 +16,6 @@ dependencies {
 
 tasks.withType<Test> {
     jvmArgs("-XX:+EnableDynamicAgentLoading")
-
-    jacoco {
-        enabled = false
-    }
 }
 
 micronautBuild {

--- a/test-type-pollution/build.gradle.kts
+++ b/test-type-pollution/build.gradle.kts
@@ -16,8 +16,12 @@ dependencies {
 
 tasks.withType<Test> {
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+}
 
-    extensions.findByType(JacocoTaskExtension::class)?.isEnabled = false
+afterEvaluate {
+    tasks.withType<Test> {
+        extensions.findByType(JacocoTaskExtension::class.java)?.isEnabled = false
+    }
 }
 
 micronautBuild {

--- a/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
+++ b/test-type-pollution/src/main/java/io/micronaut/test/typepollution/TypePollutionTransformer.java
@@ -16,6 +16,7 @@
 package io.micronaut.test.typepollution;
 
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.TypeConstantAdjustment;
 import net.bytebuddy.description.type.TypeDescription;
@@ -75,6 +76,12 @@ public final class TypePollutionTransformer implements AgentBuilder.Transformer 
             .with(AgentBuilder.LambdaInstrumentationStrategy.DISABLED)
             .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
             .with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
+            // this is the default ignore matcher except we don't ignore synthetic types
+            .ignore(
+                new AgentBuilder.RawMatcher.ForElementMatchers(ElementMatchers.any(), ElementMatchers.isBootstrapClassLoader().or(ElementMatchers.isExtensionClassLoader())))
+            .or(new AgentBuilder.RawMatcher.ForElementMatchers(ElementMatchers.nameStartsWith("net.bytebuddy.")
+                .and(ElementMatchers.not(ElementMatchers.nameStartsWith(NamingStrategy.BYTE_BUDDY_RENAME_PACKAGE + ".")))
+                .or(ElementMatchers.nameStartsWith("sun.reflect.").or(ElementMatchers.nameStartsWith("jdk.internal.reflect.")))))
             .type(ElementMatchers.any()
                 .and(ElementMatchers.not(ElementMatchers.nameStartsWith("net.bytebuddy.")))
                 .and(ElementMatchers.not(ElementMatchers.nameStartsWith("com.sun")))


### PR DESCRIPTION
ByteBuddy ignores synthetics by default.

I don't think a test is possible, the tests use a different code path. I've checked this works in core though.