### PR TITLE
Rebuild initial ctx when first test method has props

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -421,7 +421,10 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
      */
     protected void beforeEach(C context, @Nullable Object testInstance, @Nullable AnnotatedElement method, List<Property> propertyAnnotations) {
         if (method != null) {
+            int testCount = (int) testProperties.compute("micronaut.test.count", (k, oldCount) -> (int) (oldCount != null ? oldCount : 0) + 1);
+            boolean shouldRebuildContext = testCount > 1;
             if (propertyAnnotations != null && !propertyAnnotations.isEmpty()) {
+                shouldRebuildContext = true;
                 for (Property property : propertyAnnotations) {
                     final String name = property.name();
                     oldValues.put(name,
@@ -432,7 +435,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 testProperties.putAll(oldValues);
             }
 
-            if (testAnnotationValue.rebuildContext()) {
+            if (testAnnotationValue.rebuildContext() && shouldRebuildContext) {
                 stopEmbeddedApplication();
                 if (applicationContext.isRunning()) {
                     applicationContext.stop();

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/RebuildContextTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/RebuildContextTest.java
@@ -1,0 +1,30 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(rebuildContext = true)
+public class RebuildContextTest {
+
+    @Inject
+    TestBean bean;
+
+    @Test
+    public void test() {
+        assertEquals(1, TestBean.counter);
+    }
+}
+
+@Context
+class TestBean {
+    static int counter = 0;
+
+    public TestBean() {
+        counter++;
+    }
+}


### PR DESCRIPTION
Otherwise we want to keep the original context as other extensions or tests may expect to have the original context. This doesn't fix the issue where these two features don't play well together, but it drastically reduces the scope where they conflict. This means that we should be able to access the same context over the test lifecycle unless we are using property annotations on the test method.