### PR TITLE
Adds Netty leak in Table of contents

### DIFF
--- a/src/main/docs/guide/nettyLeak.adoc
+++ b/src/main/docs/guide/nettyLeak.adoc
@@ -8,7 +8,7 @@ JUnit Jupiter and Spock extensions that performs leak detection on all tests.
 
 dependency:io.micronaut.test:micronaut-test-netty-leak[scope="testRuntimeOnly"]
 
-WARNING: This extension will only work with Netty 4.2.7 and later.
+WARNING: This extension will only work with Netty 4.2.7 and later. [Micronaut 4.10.0](https://github.com/micronaut-projects/micronaut-platform/releases/tag/v4.10.0) ships with Netty 4.2.7.
 
 To enable JUnit leak detection, either extend your test like this:
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -38,6 +38,7 @@ kotest5:
   kotest5DefiningAdditionalTestSpecificProperties: Defining Additional Test Specific Properties
   kotest5ConstructorInjectionCaveats: Constructor Injection Caveats
   kotest5RefreshingInjectedBeansBasedOnRequiresUponPropertiesChanges: Refreshing injected beans based on `@Requires` upon properties changes
+nettyLeak: Netty Leak Detection
 restAssured: REST Assured
 sql: Loading SQL before tests
 typePollution: Type pollution


### PR DESCRIPTION
Also, tell users which version of Micronaut does ship with Netty 4.2.7