### PR TITLE
Move spock leak detection to shared initializer

### DIFF
--- a/test-netty-leak/src/main/java/io/micronaut/test/leak/SpockLeakPresenceExtension.java
+++ b/test-netty-leak/src/main/java/io/micronaut/test/leak/SpockLeakPresenceExtension.java
@@ -26,7 +26,7 @@ public final class SpockLeakPresenceExtension implements IGlobalExtension {
 
     @Override
     public void visitSpec(SpecInfo spec) {
-        spec.addSetupSpecInterceptor(invocation -> {
+        spec.addSharedInitializerInterceptor(invocation -> {
             WithTransferableScope.SCOPE.set(new LeakPresenceDetector.ResourceScope(spec.getDisplayName()));
             invocation.proceed();
         });


### PR DESCRIPTION
SetupSpec is not early enough and may miss some resources.

Not urgent, doesn't have to make it into 4.10.0