### PR TITLE
graal: initialize at build time junit-platform classes

### DIFF
--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,2 +1,6 @@
 Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension \
-       --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener
+       --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener \
+       --initialize-at-build-time=org.junit.platform.launcher.core.LauncherPhase \
+       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator \
+       --initialize-at-build-time=org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue \
+       --initialize-at-build-time=org.junit.platform.launcher.core.DiscoveryIssueNotifier


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-test/issues/1297

Tracing the initialization looks like:

```
Error: Classes that should be initialized at run time got initialized during image building:
------------------------------------------------------------------------------------------------------------------------ org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue was unintentionally initialized at build time. To see why org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue got initialized use --trace-class-initialization=org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue

org.junit.platform.launcher.core.LauncherPhase was unintentionally initialized at build time. org.junit.platform.launcher.core.LauncherPhase caused initialization of this class with the following trace:
		at org.junit.platform.launcher.core.LauncherPhase.<clinit>(LauncherPhase.java:29)
		at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:83)
		at org.junit.platform.launcher.core.DelegatingLauncher.discover(DelegatingLauncher.java:42)
		at org.junit.platform.launcher.core.InterceptingLauncher.lambda$discover$0(InterceptingLauncher.java:33)
		at org.junit.platform.launcher.core.InterceptingLauncher$$Lambda/0x0000007801328c50.proceed(Unknown Source)
		at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
		at org.junit.platform.launcher.core.InterceptingLauncher.discover(InterceptingLauncher.java:33)
		at org.junit.platform.launcher.core.DelegatingLauncher.discover(DelegatingLauncher.java:42)
		at org.junit.platform.launcher.core.SessionPerRequestLauncher.discover(SessionPerRequestLauncher.java:59)
		at org.graalvm.junit.platform.JUnitPlatformFeature.discoverTestsAndRegisterTestClassesForReflection(JUnitPlatformFeature.java:135)
		at org.graalvm.junit.platform.JUnitPlatformFeature.beforeAnalysis(JUnitPlatformFeature.java:94)
		at com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$9(NativeImageGenerator.java:774)
		at com.oracle.svm.hosted.NativeImageGenerator$$Lambda/0x00000078012b3cd8.accept(Unknown Source)
		at com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:90)
		at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:774)
		at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:593)
		at com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:551)
		at com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:539)
		at com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:721)
		at com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:143)
		at com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:98)

```