### PR TITLE
Junit 6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ managed-assertj = "3.27.4"
 managed-hamcrest = "3.0"
 managed-mockito = "5.20.0"
 managed-mockk = "1.13.17"
-managed-junit = "5.14.0"
+managed-junit = "6.0.0"
 managed-junit-platform = "1.14.0"
 managed-rest-assured = "5.5.6"
 managed-kotest = "5.9.1"
@@ -55,17 +55,16 @@ managed-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engin
 managed-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "managed-junit" }
 managed-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "managed-junit" }
 managed-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "managed-junit" }
-junit-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "managed-junit-platform" }
 
-managed-junit-platform-suite-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "managed-junit-platform" }
-managed-junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "managed-junit-platform" }
-managed-junit-platform-suite-api = { module = "org.junit.platform:junit-platform-suite-api", version.ref = "managed-junit-platform" }
-managed-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "managed-junit-platform" }
+managed-junit-platform-suite-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "managed-junit" }
+managed-junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "managed-junit" }
+managed-junit-platform-suite-api = { module = "org.junit.platform:junit-platform-suite-api", version.ref = "managed-junit" }
+managed-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "managed-junit" }
 managed-junit-platform-runner = { module = "org.junit.platform:junit-platform-runner", version.ref = "managed-junit-platform" }
-managed-junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "managed-junit-platform" }
-managed-junit-platform-console = { module = "org.junit.platform:junit-platform-console", version.ref = "managed-junit-platform" }
+managed-junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "managed-junit" }
+managed-junit-platform-console = { module = "org.junit.platform:junit-platform-console", version.ref = "managed-junit" }
 managed-junit-platform-jfr = { module = "org.junit.platform:junit-platform-jfr", version.ref = "managed-junit-platform" }
-managed-junit-platform-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "managed-junit-platform" }
+managed-junit-platform-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "managed-junit" }
 
 managed-bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "managed-bytebuddy" }
 managed-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "managed-bytebuddy" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ managed-hamcrest = "3.0"
 managed-mockito = "5.20.0"
 managed-mockk = "1.13.17"
 managed-junit = "6.0.0"
-managed-junit-platform = "1.14.0"
 managed-rest-assured = "5.5.6"
 managed-kotest = "5.9.1"
 managed-spock = "2.3-groovy-4.0"
@@ -60,10 +59,8 @@ managed-junit-platform-suite-engine = { module = "org.junit.platform:junit-platf
 managed-junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "managed-junit" }
 managed-junit-platform-suite-api = { module = "org.junit.platform:junit-platform-suite-api", version.ref = "managed-junit" }
 managed-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "managed-junit" }
-managed-junit-platform-runner = { module = "org.junit.platform:junit-platform-runner", version.ref = "managed-junit-platform" }
 managed-junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "managed-junit" }
 managed-junit-platform-console = { module = "org.junit.platform:junit-platform-console", version.ref = "managed-junit" }
-managed-junit-platform-jfr = { module = "org.junit.platform:junit-platform-jfr", version.ref = "managed-junit-platform" }
 managed-junit-platform-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "managed-junit" }
 
 managed-bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "managed-bytebuddy" }

--- a/test-bom/build.gradle
+++ b/test-bom/build.gradle
@@ -9,5 +9,8 @@ repositories {
 micronautBom {
     suppressions {
         acceptedLibraryRegressions.add("micronaut-test-kotest")
+        acceptedLibraryRegressions.add("junit-platform-runner")
+        acceptedLibraryRegressions.add("junit-platform-jfr")
+        acceptedVersionRegressions.add("junit-platform")
     }
 }

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -47,9 +47,8 @@ kotlin {
 }
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.named("test") {

--- a/test-kotest5/build.gradle
+++ b/test-kotest5/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id "io.micronaut.build.internal.micronaut-test-module"
     id "org.jetbrains.kotlin.jvm"
@@ -39,8 +41,8 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
     }
 }
 


### PR DESCRIPTION
https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0

> To simplify dependency management, all modules of JUnit Platform, Jupiter, and Vintage now use the same version number: 6.0.0.

Close: https://github.com/micronaut-projects/micronaut-test/issues/1276