### PR TITLE
remove test-resources dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ managed-spock = "2.4-M7-groovy-5.0"
 managed-bytebuddy = "1.17.8"
 kotlin = "2.1.21"
 graal-svm = "24.2.2"
+testcontainers = "2.0.2"
 
 micronaut-platform = "4.10.3"
 micronaut = "5.0.0-M3"
@@ -21,7 +22,6 @@ micronaut-serde = "3.0.0-M1"
 micronaut-spring = "5.12.0"
 micronaut-sql = "6.3.2"
 micronaut-reactor = "4.0.0-M1"
-micronaut-test-resources = "2.10.1"
 micronaut-gradle-plugin = "4.6.1"
 
 [libraries]
@@ -36,7 +36,6 @@ micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.r
 micronaut-spring = { module = "io.micronaut.spring:micronaut-spring-bom", version.ref = "micronaut-spring" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
 micronaut-reactor = { module = 'io.micronaut.reactor:micronaut-reactor-bom', version.ref = "micronaut-reactor" }
-micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 
 managed-assertj-core = { module = "org.assertj:assertj-core", version.ref = "managed-assertj" }
 managed-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "managed-hamcrest" }
@@ -63,8 +62,14 @@ managed-junit-platform-testkit = { module = "org.junit.platform:junit-platform-t
 managed-bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "managed-bytebuddy" }
 managed-bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "managed-bytebuddy" }
 
-testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter"}
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
+testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
+testcontainers-r2dbc = { module = "org.testcontainers:testcontainers-r2dbc" }
+
 # BOMs
+boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+
 boms-junit = { module = "org.junit:junit-bom", version.ref = "managed-junit" }
 boms-kotest = { module = "io.kotest:kotest-bom", version.ref = "managed-kotest" }
 boms-spock = { module = "org.spockframework:spock-bom", version.ref = "managed-spock" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ managed-spock = "2.4-M7-groovy-5.0"
 managed-bytebuddy = "1.17.8"
 kotlin = "2.1.21"
 graal-svm = "24.2.2"
-testcontainers = "2.0.2"
+managed-testcontainers = "2.0.2"
 
 micronaut-platform = "4.10.3"
 micronaut = "5.0.0-M3"
@@ -68,7 +68,7 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-jun
 testcontainers-r2dbc = { module = "org.testcontainers:testcontainers-r2dbc" }
 
 # BOMs
-boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
 
 boms-junit = { module = "org.junit:junit-bom", version.ref = "managed-junit" }
 boms-kotest = { module = "io.kotest:kotest-bom", version.ref = "managed-kotest" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,6 @@ micronautBuild {
     importMicronautCatalog("micronaut-sql")
     importMicronautCatalog("micronaut-r2dbc")
     importMicronautCatalog("micronaut-reactor")
-    importMicronautCatalog("micronaut-test-resources")
     importMicronautCatalog("micronaut-hibernate-validator")
 }
 
@@ -33,6 +32,6 @@ include "test-junit5"
 include "test-kotest5"
 include "test-netty-leak"
 //include "test-rest-assured"
-//include 'test-suite-sql-r2dbc'
+include 'test-suite-sql-r2dbc'
 include 'test-suite-at-sql-jpa'
 include 'test-type-pollution'

--- a/test-suite-at-sql-jpa/build.gradle.kts
+++ b/test-suite-at-sql-jpa/build.gradle.kts
@@ -21,10 +21,9 @@ dependencies {
     testImplementation(libs.managed.junit.jupiter.api)
     testImplementation(libs.managed.junit.platform.launcher)
     testImplementation(projects.micronautTestJunit5)
-    testImplementation(mnTestResources.testcontainers.postgres)
-    testImplementation(platform(mnTestResources.boms.testcontainers))
+    testImplementation(platform(libs.boms.testcontainers))
     testImplementation(libs.testcontainers.junit.jupiter)
-
+    testImplementation(libs.testcontainers.postgresql)
     testRuntimeOnly(libs.managed.junit.jupiter.engine)
 }
 

--- a/test-suite-at-sql-jpa/src/test/java/example/micronaut/PostgreSQL.java
+++ b/test-suite-at-sql-jpa/src/test/java/example/micronaut/PostgreSQL.java
@@ -1,7 +1,6 @@
 package example.micronaut;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.test.support.TestPropertyProvider;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.util.Map;

--- a/test-suite-sql-r2dbc/build.gradle.kts
+++ b/test-suite-sql-r2dbc/build.gradle.kts
@@ -2,7 +2,6 @@ import io.micronaut.testresources.buildtools.KnownModules.R2DBC_MYSQL
 
 plugins {
     id("io.micronaut.minimal.library")
-    id("io.micronaut.test-resources")
     id("io.micronaut.graalvm") // Required to configure Graal for nativeTest
 }
 
@@ -21,21 +20,19 @@ dependencies {
     testImplementation(projects.micronautTestJunit5)
     testImplementation(mnData.micronaut.data.r2dbc)
     testImplementation(mnSerde.micronaut.serde.jackson)
-    testImplementation(platform(mnTestResources.boms.testcontainers))
-    testImplementation(libs.testcontainers.junit.jupiter)
 
+    testImplementation(platform(libs.boms.testcontainers))
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.mysql)
+    testImplementation(libs.testcontainers.r2dbc)
+    testRuntimeOnly(mnSql.mysql.connector.j)
     testRuntimeOnly(mnLogging.logback.classic)
     testRuntimeOnly(mnR2dbc.r2dbc.mysql)
     testRuntimeOnly(libs.managed.junit.platform.launcher)
     testRuntimeOnly(mn.micronaut.http.server.netty)
-    testResourcesService(mnSql.mysql.connector.java)
 }
 
 micronaut {
     testRuntime("junit5")
     importMicronautPlatform.set(false)
-    testResources {
-        version.set(libs.versions.micronaut.test.resources)
-        additionalModules.add(R2DBC_MYSQL)
-    }
 }

--- a/test-suite-sql-r2dbc/src/test/java/io/micronaut/test/r2dbc/MySQL.java
+++ b/test-suite-sql-r2dbc/src/test/java/io/micronaut/test/r2dbc/MySQL.java
@@ -1,0 +1,37 @@
+package io.micronaut.test.r2dbc;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+public class MySQL {
+    private static final String IMAGE_NAME = "mysql:lts";
+    private static MySQLContainer<?> mysql;
+
+    public static Map<String, String> getProperties() {
+        if (mysql == null) {
+            mysql = new MySQLContainer<>(DockerImageName.parse(IMAGE_NAME))
+                .withConfigurationOverride(null); // for Native tests
+            mysql.start();
+            do {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } while(!mysql.isRunning());
+            return getProperties(mysql);
+        } else {
+            return getProperties(mysql);
+        }
+    }
+
+    private static Map<String, String> getProperties(MySQLContainer mysql) {
+        return Map.of(
+            "r2dbc.datasources.default.url", mysql.getJdbcUrl().replace("jdbc", "r2dbc"),
+            "r2dbc.datasources.default.username", mysql.getUsername(),
+            "r2dbc.datasources.default.password", mysql.getPassword()
+        );
+    }
+}

--- a/test-suite-sql-r2dbc/src/test/java/io/micronaut/test/r2dbc/MySqlConnectionTest.java
+++ b/test-suite-sql-r2dbc/src/test/java/io/micronaut/test/r2dbc/MySqlConnectionTest.java
@@ -3,11 +3,16 @@ package io.micronaut.test.r2dbc;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.annotation.Sql;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import io.r2dbc.spi.ConnectionFactory;
 import jakarta.inject.Inject;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Flux;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,8 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @MicronautTest
 @Property(name = "r2dbc.datasources.default.db-type", value = "mysql")
 @Sql(value = {"classpath:create.sql", "classpath:datasource_1_insert.sql"}, resourceType = ConnectionFactory.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Testcontainers(disabledWithoutDocker = true)
-class MySqlConnectionTest  {
+class MySqlConnectionTest implements TestPropertyProvider {
+    @Override
+    @NonNull
+    public Map<String, String> getProperties() {
+        return MySQL.getProperties();
+    }
 
     @Inject
     ConnectionFactory connectionFactory;

--- a/test-suite-sql-r2dbc/src/test/resources/META-INF/native-image/io.micronaut.test/test-suite-sql-r2dbc/native-image.properties
+++ b/test-suite-sql-r2dbc/src/test/resources/META-INF/native-image/io.micronaut.test/test-suite-sql-r2dbc/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger

--- a/test-suite-sql-r2dbc/src/test/resources/application-test.properties
+++ b/test-suite-sql-r2dbc/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
-test-resources.containers.mysql.image-name=mysql:lts
+r2dbc.datasources.default.dialect=MYSQL
+


### PR DESCRIPTION
This Pull-Request removes the `test-resources` dependency to avoid a chicken and egg problem. Micronaut Modules should not consume `test-resources` and instead use test-containers directly. 

@melix, maybe we should define the test-containers version in the Micronaut Build Gradle Plugin and import the BOM directly in the test classpath. 

An alternative would be to do what I do in this PR, define `test-containers` as a managed version in Micronaut Test and then test-resources and other modules can consume this version.

