### PR TITLE
Isolate Kotest restrictions to Kotest docs

### DIFF
--- a/src/main/docs/guide/includes/transaction.adoc
+++ b/src/main/docs/guide/includes/transaction.adoc
@@ -25,6 +25,3 @@ The following transaction modes are supported:
   the test. This transaction is always committed.
 * `SINGLE_TRANSACTION` - All setup methods are wrapped in the same transaction as the test. Cleanup methods are wrapped
   in separate transactions.
-
-NOTE: Setup and cleanup methods are not wrapped in transactions in Kotest currently. As a result, transaction modes have
-no effect in Kotest.

--- a/src/main/docs/guide/kotest5/kotest5TransactionSemantics.adoc
+++ b/src/main/docs/guide/kotest5/kotest5TransactionSemantics.adoc
@@ -1,1 +1,4 @@
 include::src/main/docs/guide/includes/transaction.adoc[]
+
+NOTE: Setup and cleanup methods are not wrapped in transactions in Kotest currently. As a result, transaction modes have
+no effect in Kotest.


### PR DESCRIPTION
The transaction restrictions from Kotest shouldn't show up under other test frameworks.