### PR TITLE
Fix Kotlin, JUnit , Mockito: @MockBean does not inject a mocked bean (#1275)

### DIFF
--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id "io.micronaut.build.internal.micronaut-test-module"
     id 'io.micronaut.graalvm' // Required to configure Graal for nativeTest
+    alias(mn.plugins.kotlin.jvm)
+    alias(mn.plugins.ksp)
 }
 
 tasks.withType(Test).configureEach {
@@ -43,6 +45,7 @@ dependencies {
 
     implementation(mn.micronaut.context)
 
+    ksp(mn.micronaut.inject.kotlin)
     testAnnotationProcessor(mn.micronaut.inject.java)
     testAnnotationProcessor(mn.micronaut.graal)
 

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -24,12 +24,15 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.FieldInjectionPoint;
 import io.micronaut.inject.InjectableBeanDefinition;
+import io.micronaut.inject.MethodInjectionPoint;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.test.annotation.MicronautTestValue;
@@ -302,24 +305,74 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             return;
         }
         findSpecInstance(context).ifPresent(specInstance -> {
+            // Handle field injection (Java-style @Inject fields)
             for (FieldInjectionPoint injectedField : specDefinition.getInjectedFields()) {
                 final boolean isMock = applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class);
                 if (isMock) {
                     final Field field = injectedField.getField();
-                    field.setAccessible(true);
-                    try {
-                        final Object mock = field.get(specInstance);
-                        if (mock instanceof InterceptedProxy) {
-                            InterceptedProxy ip = (InterceptedProxy) mock;
-                            final Object target = ip.interceptedTarget();
-                            field.set(specInstance, target);
-                        }
-                    } catch (IllegalAccessException e) {
-                        // continue
+                    alignField(field, specInstance);
+                }
+            }
+
+            // Handle method injection (Micronaut's KSP processor generates setter injection for Kotlin,
+            // even when @Inject is on the field, unlike the Java annotation processor which uses field injection)
+            for (MethodInjectionPoint<?, ?> injectedMethod : specDefinition.getInjectedMethods()) {
+                final Argument<?>[] args = injectedMethod.getArguments();
+                if (args.length != 1) {
+                    continue;
+                }
+                final boolean isMock = applicationContext.resolveMetadata(args[0].getType()).isAnnotationPresent(MockBean.class);
+                if (!isMock) {
+                    continue;
+                }
+
+                // Derive field name from setter method name (e.g., setEchoService -> echoService)
+                String methodName = injectedMethod.getName();
+                if (methodName.startsWith("set") && methodName.length() > 3) {
+                    String fieldName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+                    Field field = findField(specInstance.getClass(), fieldName);
+                    if (field != null) {
+                        alignField(field, specInstance);
                     }
                 }
             }
         });
+    }
+
+    /**
+     * Sets the field to have the underlying mock rather than the InterceptedProxy.
+     *
+     * @param field to modify
+     * @param specInstance the context container
+     */
+    private void alignField(@NonNull Field field, @NonNull Object specInstance) {
+        field.setAccessible(true);
+        try {
+            final Object mock = field.get(specInstance);
+            if (mock instanceof InterceptedProxy) {
+                InterceptedProxy ip = (InterceptedProxy) mock;
+                final Object target = ip.interceptedTarget();
+                field.set(specInstance, target);
+            }
+        } catch (IllegalAccessException e) {
+            // continue
+        }
+    }
+
+    /**
+     * Find a field by name, searching up the class hierarchy.
+     */
+    @Nullable
+    private Field findField(@NonNull Class<?> clazz, @NonNull String fieldName) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
     }
 
     private Optional<?> findSpecInstance(ExtensionContext context) {

--- a/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
+++ b/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
@@ -1,0 +1,47 @@
+package io.micronaut.test.junit5
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+/**
+ * Verifies that Kotlin `lateinit var` properties can be injected
+ */
+@MicronautTest
+open class KotlinJunitTest {
+
+    @Inject
+    lateinit var application: EmbeddedApplication<*>
+
+    @Inject
+    lateinit var echoService: EchoServiceImpl
+
+    @Test
+    fun testItWorks() {
+        Assertions.assertTrue(application.isRunning)
+    }
+
+    @Test
+    fun echoServiceIsMocked() {
+        Assertions.assertFalse(echoService is InterceptedProxy<*>)
+        Assertions.assertTrue(Mockito.mockingDetails(echoService).isMock)
+    }
+
+    @MockBean(EchoServiceImpl::class)
+    open fun echoService(): EchoServiceImpl {
+        return Mockito.mock(EchoServiceImpl::class.java)
+    }
+}
+
+@Singleton
+open class EchoServiceImpl {
+  open fun echo(message: String): String {
+    return message
+  }
+}


### PR DESCRIPTION
MicronautJunit5Extension was not handling MethodInjectionPoints. Kotlin `lateinit var`s get turned into MethodInjectionPoints by KSP. Accordingly, these fields were not having their mocks aligned.

The MicronautSpockExtension already handled MethodInjectionPoint and was the blueprint for the JUnit implementation.

Fixes #1275 