### PR TITLE
Fix MockBean with rebuildContext=true and nested tests (#1203)

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -301,6 +301,14 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         if (specDefinition == null) {
             return;
         }
+        // When rebuildContext=true with nested tests, the outer test instance persists across nested tests
+        // but was injected before the context rebuild. After rebuilding, its fields still reference beans
+        // from the old (now stopped) context. We must re-inject it with beans from the new context before
+        // attempting to unwrap proxies, otherwise interceptedTarget() will fail trying to resolve beans
+        // from the stopped context.
+        if (testAnnotationValue != null && testAnnotationValue.rebuildContext() && isNestedTestClass(context.getRequiredTestClass())) {
+            injectEnclosingTestInstances(context);
+        }
         findSpecInstance(context).ifPresent(specInstance -> {
             for (FieldInjectionPoint injectedField : specDefinition.getInjectedFields()) {
                 final boolean isMock = applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class);

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedTest.java
@@ -1,0 +1,52 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Demonstrates that a {@code @MockBean} properly injects into {@code @Nested} classes when
+ * {@code rebuildContext = true}.
+ * <p>
+ * See {@link MultipleNestedTestClassesTest} for the test that doesn't make use of
+ * {@code rebuildContext}
+ */
+@MicronautTest(rebuildContext = true)
+public class MockBeanNestedTest {
+
+    @Inject
+    SomeBean someBean;
+
+    @MockBean(SomeBean.class)
+    public SomeBean someBean() {
+        return mock(SomeBean.class);
+    }
+
+    @Nested
+    class FirstNestedClass {
+
+        @Test
+        void test() {
+            assertNotNull(someBean);
+        }
+    }
+
+    @Nested
+    class SecondNestedClass {
+
+        @Test
+        void test() {
+            assertNotNull(someBean);
+        }
+    }
+
+    @Singleton
+    public static class SomeBean {
+    }
+}


### PR DESCRIPTION
When @MicronautTest(rebuildContext=true) is used with @Nested test classes and @MockBean, the second nested test would fail with "Cannot resolve beans until the context is running".

Root cause: The outer test instance persists across nested tests, but when the context is rebuilt for the second nested test, only the current (nested) test instance gets re-injected. The outer instance still holds proxies from the old stopped context. When alignMocks() tries to unwrap these proxies via interceptedTarget(), it fails because it attempts to resolve beans from the stopped context.

Solution: In alignMocks(), detect when we're in a nested test with rebuildContext=true and re-inject the enclosing test instances before unwrapping proxies. This ensures the outer instance has fresh proxies from the new context.

Fixes #1203

I've been using this in my project for about a week with several `rebuildContext = true` tests and haven't encountered any problems.