### PR TITLE
remove classes initialization for native image jdk 25

### DIFF
--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,6 +1,2 @@
 Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension \
-       --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener \
-       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator \
-       --initialize-at-build-time=org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue \
-       --initialize-at-build-time=org.junit.jupiter.engine.discovery.MethodSegmentResolver \
-       --initialize-at-build-time=org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger
+       --initialize-at-build-time=org.junit.jupiter.engine.discovery.MethodSegmentResolver


### PR DESCRIPTION
This classes initialization at native image build time produce issues in other modules for jdk 25 native build, more than than initialization different now for jdk 25, so we need to remove those entries.