### PR TITLE
Remove native-image initialization config in micronaut-test (Java 21/25 compatibility)

### DIFF
--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,3 +1,5 @@
 Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension \
        --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener \
-       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator
+       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator \
+       --initialize-at-build-time=org.junit.platform.launcher.core.DiscoveryIssueNotifier
+

--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,6 +1,3 @@
 Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension \
        --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener \
-       --initialize-at-build-time=org.junit.platform.launcher.core.LauncherPhase \
-       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator \
-       --initialize-at-build-time=org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue \
-       --initialize-at-build-time=org.junit.platform.launcher.core.DiscoveryIssueNotifier
+       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator

--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/native-image.properties
@@ -1,5 +1,3 @@
 Args = --initialize-at-run-time=io.micronaut.test.extensions.junit5.MicronautJunit5Extension \
        --initialize-at-build-time=org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener \
-       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator \
-       --initialize-at-build-time=org.junit.platform.launcher.core.DiscoveryIssueNotifier
-
+       --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryCreator

--- a/test-suite-sql-r2dbc/build.gradle.kts
+++ b/test-suite-sql-r2dbc/build.gradle.kts
@@ -39,3 +39,8 @@ micronaut {
         additionalModules.add(R2DBC_MYSQL)
     }
 }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}


### PR DESCRIPTION
These entries are already provided by GraalVM Native Build Tools https://github.com/graalvm/native-build-tools/blame/master/common/junit-platform-native/src/main/resources/initialize-at-buildtime
For:
Java 21 → configuration is already supplied
Java 25 → the entries are not required and produce native failures.
i test changes locally against micronaut application for jdk 21 and 25 both nativeTest pass.
Closes: #1400 