### PR TITLE
fix: avoid resolving mock metadata by erased field type

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -290,8 +290,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         }
         findSpecInstance(context).ifPresent(specInstance -> {
             for (FieldInjectionPoint injectedField : specDefinition.getInjectedFields()) {
-                final boolean isMock = applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class);
-                if (isMock) {
+                if (isMockedInjectionPoint(injectedField)) {
                     final Field field = injectedField.getField();
                     field.setAccessible(true);
                     try {
@@ -307,6 +306,21 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
                 }
             }
         });
+    }
+
+    private boolean isMockedInjectionPoint(FieldInjectionPoint<?, ?> injectedField) {
+        if (injectedField.getAnnotationMetadata().isAnnotationPresent(MockBean.class)) {
+            return true;
+        }
+        return isMockedInjectionPoint(injectedField.asArgument());
+    }
+
+    private <T> boolean isMockedInjectionPoint(Argument<T> injectedArgument) {
+        Qualifier<T> qualifier = resolveQualifier(injectedArgument);
+        return applicationContext.getBeanDefinitions(injectedArgument, qualifier)
+            .stream()
+            .filter(definition -> definition.isCandidateBean(injectedArgument))
+            .anyMatch(definition -> definition.getAnnotationMetadata().isAnnotationPresent(MockBean.class));
     }
 
     private Optional<?> findSpecInstance(ExtensionContext context) {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/GenericRepositoryInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/GenericRepositoryInjectionTest.java
@@ -1,0 +1,52 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Property(name = "spec.name", value = "GenericRepositoryInjectionTest")
+@MicronautTest
+class GenericRepositoryInjectionTest {
+
+    @Inject
+    private RepositoryContract<String, String> stringRepository;
+
+    @Inject
+    private RepositoryContract<Long, Long> longRepository;
+
+    @Test
+    void injectsGenericRepositories() {
+        assertNotNull(stringRepository);
+        assertNotNull(longRepository);
+    }
+
+    interface RepositoryContract<K, V> {
+        String get(K key, V value);
+    }
+
+    @Singleton
+    @Secondary
+    @Requires(property = "spec.name", value = "GenericRepositoryInjectionTest")
+    static class StringRepository implements RepositoryContract<String, String> {
+        @Override
+        public String get(String key, String value) {
+            return key + value;
+        }
+    }
+
+    @Singleton
+    @Secondary
+    @Requires(property = "spec.name", value = "GenericRepositoryInjectionTest")
+    static class LongRepository implements RepositoryContract<Long, Long> {
+        @Override
+        public String get(Long key, Long value) {
+            return key + ":" + value;
+        }
+    }
+}


### PR DESCRIPTION
## What changed

This updates `MicronautJunit5Extension.alignMocks` so it no longer determines mock fields by resolving bean metadata from the injected field's erased raw type.

Instead, the new logic:

- still short-circuits direct field-level `@MockBean` usage
- otherwise resolves candidate bean definitions for the injected field's full `Argument<?>` plus qualifier
- and treats the field as a mock only when one of those matching candidate bean definitions is annotated with `@MockBean`

A regression test was added in `GenericRepositoryInjectionTest`.

## Why

The old code called:

```java
applicationContext.resolveMetadata(injectedField.getType())
```

That lookup only uses the raw field type. When multiple beans share the same erased generic type, such as `RepositoryContract<String, String>` and `RepositoryContract<Long, Long>`, the metadata resolution path can become ambiguous and fail with:

```text
java.util.NoSuchElementException
at io.micronaut.context.DefaultBeanContext.lastChanceResolve(...)
at io.micronaut.test.extensions.junit5.MicronautJunit5Extension.alignMocks(...)
```

A naive field-metadata-only check is not sufficient because many existing Mockito-based tests inject collaborator fields with `@Inject`, while the `@MockBean` annotation lives on the producer method or field elsewhere in the test class.

Matching against candidate bean definitions for the full injected `Argument` preserves generic specificity, keeps qualifier handling intact, and still recognizes existing `@MockBean`-backed collaborator injections.

## Reproduction

Added `GenericRepositoryInjectionTest` in `test-junit5`, which reproduces the generic injection failure before the fix and passes after it.

## Verification

Verified on Java 17:

```bash
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.GenericRepositoryInjectionTest'
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.MathCollaboratorTest'
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.MathCollaboratorRebuildContextTest'
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.ApplicationRunTest'
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.ApplicationRunAnotherTest'
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.MathCollaboratorBaseTest'
```

Verified on Java 21:

```bash
./gradlew :micronaut-test-junit5:test --tests 'io.micronaut.test.junit5.GenericRepositoryInjectionTest'
```

Fixes #11592