### PR TITLE
add deduceEnvironments flag into MicronautTest annotation

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/annotation/MicronautTestValue.java
+++ b/test-core/src/main/java/io/micronaut/test/annotation/MicronautTestValue.java
@@ -40,6 +40,7 @@ public class MicronautTestValue {
     private final boolean startApplication;
 
     private final boolean resolveParameters;
+    private final boolean deduceEnvironment;
 
     /**
      * Default constructor.
@@ -55,13 +56,15 @@ public class MicronautTestValue {
      * @param transactionMode The transaction mode
      * @param startApplication Whether the start the app
      * @param resolveParameters Whether to resolve parameters to beans
+     * @param deduceEnvironment Whether to deduce additional active environments
      */
     @Creator
     public MicronautTestValue(Class<?> application, String[] environments, String[] packages, String[] propertySources,
                               boolean rollback, boolean transactional, boolean rebuildContext,
                               Class<? extends ApplicationContextBuilder>[] contextBuilder, TransactionMode transactionMode,
                               boolean startApplication,
-                              boolean resolveParameters) {
+                              boolean resolveParameters,
+                              boolean deduceEnvironment) {
         this.application = application;
         this.environments = environments;
         this.packages = packages;
@@ -73,6 +76,7 @@ public class MicronautTestValue {
         this.transactionMode = transactionMode;
         this.startApplication = startApplication;
         this.resolveParameters = resolveParameters;
+        this.deduceEnvironment = deduceEnvironment;
     }
 
     /**
@@ -162,5 +166,12 @@ public class MicronautTestValue {
      */
     public boolean isResolveParameters() {
         return resolveParameters;
+    }
+
+    /**
+     * @return Whether to deduce additional active environments
+     */
+    public boolean deduceEnvironment() {
+        return deduceEnvironment;
     }
 }

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -296,6 +296,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
             testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotationValue.rollback()));
             testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
             testProperties.put(TEST_TRANSACTION_MODE, String.valueOf(testAnnotationValue.transactionMode()));
+            testProperties.put(Environment.DEDUCE_ENVIRONMENT_PROPERTY, String.valueOf(testAnnotationValue.deduceEnvironment()));
             final Class<?> application = testAnnotationValue.application();
             if (application != void.class) {
                 builder.mainClass(application);

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -429,7 +429,8 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             micronautTest.contextBuilder(),
             micronautTest.transactionMode(),
             micronautTest.startApplication(),
-            micronautTest.resolveParameters());
+            micronautTest.resolveParameters(),
+            micronautTest.deduceEnvironment());
     }
 
     private boolean isNestedTestClass(Class<?> testClass) {

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/annotation/MicronautTest.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/annotation/MicronautTest.java
@@ -116,4 +116,11 @@ public @interface MicronautTest {
      * @return Whether to resolve test method parameters as beans.
      */
     boolean resolveParameters() default true;
+
+    /**
+     * Controls whether Micronaut should deduce additional active environments.
+     *
+     * @return {@code false} to mimic setting {@code MICRONAUT_ENV_DEDUCTION=false}
+     */
+    boolean deduceEnvironment() default true;
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/DisableEnvironmentDeductionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/DisableEnvironmentDeductionTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(deduceEnvironment = false)
+class DisableEnvironmentDeductionTest {
+
+    @Inject
+    Environment environment;
+
+    @Test
+    void environmentDeductionPropertyIsFalse() {
+        assertEquals(Boolean.FALSE, environment.getProperty(Environment.DEDUCE_ENVIRONMENT_PROPERTY, Boolean.class).orElse(null));
+    }
+}

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/MicronautKotest5Extension.kt
@@ -130,6 +130,7 @@ object MicronautKotest5Extension : TestListener, ConstructorExtension, TestCaseE
             micronautTest.transactionMode,
             micronautTest.startApplication,
             false,
+            micronautTest.deduceEnvironment,
         )
     }
 

--- a/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/annotation/MicronautTest.kt
+++ b/test-kotest5/src/main/kotlin/io/micronaut/test/extensions/kotest5/annotation/MicronautTest.kt
@@ -93,4 +93,5 @@ annotation class MicronautTest(
          *
          * @return true if [io.micronaut.runtime.EmbeddedApplication] should be started
          */
-        val startApplication: Boolean = true)
+        val startApplication: Boolean = true,
+        val deduceEnvironment: Boolean = true)

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/DisableEnvironmentDeductionTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/DisableEnvironmentDeductionTest.kt
@@ -1,0 +1,20 @@
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.env.Environment
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import jakarta.inject.Inject
+
+@MicronautTest(deduceEnvironment = false)
+internal class DisableEnvironmentDeductionTest : StringSpec() {
+
+    @Inject
+    lateinit var environment: Environment
+
+    init {
+        "environment deduction property is false" {
+            environment.getProperty(Environment.DEDUCE_ENVIRONMENT_PROPERTY, Boolean::class.java).orElse(null) shouldBe false
+        }
+    }
+}

--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -218,7 +218,8 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
                     micronautTest.contextBuilder(),
                     micronautTest.transactionMode(),
                     micronautTest.startApplication(),
-                    false);
+                    false,
+                    micronautTest.deduceEnvironment());
         } else {
             return null;
         }

--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/annotation/MicronautTest.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/annotation/MicronautTest.java
@@ -105,4 +105,11 @@ public @interface MicronautTest {
      * @return true if {@link io.micronaut.runtime.EmbeddedApplication} should be started
      */
     boolean startApplication() default true;
+
+    /**
+     * Controls whether Micronaut should deduce additional active environments.
+     *
+     * @return {@code false} to mimic setting {@code MICRONAUT_ENV_DEDUCTION=false}
+     */
+    boolean deduceEnvironment() default true;
 }

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/DisableEnvironmentDeductionSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/DisableEnvironmentDeductionSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.env.Environment
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(deduceEnvironment = false)
+class DisableEnvironmentDeductionSpec extends Specification {
+
+    @Inject
+    Environment environment
+
+    void "environment deduction property is false"() {
+        expect:
+            environment.getProperty(Environment.DEDUCE_ENVIRONMENT_PROPERTY, Boolean).orElse(null) == false
+    }
+}


### PR DESCRIPTION
The PR adds the deduceEnvironments which by default is set to true and provides value for `MICRONAUT_ENV_DEDUCTION` env variable