### PR TITLE
Fix @Value injection for JUnit test parameters

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -387,11 +387,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         if (argument != null) {
             Optional<String> v = argument.getAnnotationMetadata().stringValue(Value.class);
             if (v.isPresent()) {
-                Optional<String> finalV = v;
-                return applicationContext.getEnvironment().getProperty(v.get(), argument)
-                    .orElseThrow(() ->
-                        new ParameterResolutionException("Unresolvable property specified to @Value: " + finalV.get())
-                    );
+                return resolveValueParameter(parameterContext, argument, v.get());
             } else {
                 v = argument.getAnnotationMetadata().stringValue(Property.class, "name");
                 if (v.isPresent()) {
@@ -407,6 +403,25 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         } else {
             return applicationContext.getBean(parameterContext.getParameter().getType());
         }
+    }
+
+    private Object resolveValueParameter(ParameterContext parameterContext, Argument<?> argument, String value) {
+        BeanDefinition<?> beanDefinition = applicationContext
+            .findBeanDefinition(parameterContext.getDeclaringExecutable().getDeclaringClass())
+            .orElse(null);
+        if (beanDefinition == null) {
+            beanDefinition = specDefinition;
+        }
+        if (beanDefinition != null) {
+            try (DefaultBeanResolutionContext resolutionContext = new DefaultBeanResolutionContext(applicationContext, beanDefinition)) {
+                return resolutionContext.resolvePropertyValue(argument, value, null, true);
+            } catch (RuntimeException e) {
+                throw new ParameterResolutionException("Unresolvable property specified to @Value: " + value, e);
+            }
+        }
+        return applicationContext.resolvePlaceholders(value)
+            .flatMap(resolved -> applicationContext.getConversionService().convert(resolved, argument))
+            .orElseThrow(() -> new ParameterResolutionException("Unresolvable property specified to @Value: " + value));
     }
 
     /**

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -406,6 +406,13 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
     }
 
     private Object resolveValueParameter(ParameterContext parameterContext, Argument<?> argument, String value) {
+        if (argument.getAnnotationMetadata().hasEvaluatedExpressions()) {
+            Object resolved = argument.getAnnotationMetadata().getValue(Value.class, argument).orElse(null);
+            if (resolved != null || argument.isDeclaredNullable()) {
+                return resolved;
+            }
+            throw new ParameterResolutionException("Unresolvable property specified to @Value: " + value);
+        }
         BeanDefinition<?> beanDefinition = applicationContext
             .findBeanDefinition(parameterContext.getDeclaringExecutable().getDeclaringClass())
             .orElse(null);

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ArgumentInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ArgumentInjectionTest.java
@@ -2,6 +2,7 @@
 package io.micronaut.test.junit5;
 
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -25,6 +26,11 @@ public class ArgumentInjectionTest {
         Assertions.assertEquals(8, result);
         assertNotNull(client);
 
+        assertEquals("test", val);
+    }
+
+    @Test
+    void testValueArgumentInjected(@Value("${foo.bar}") String val) {
         assertEquals("test", val);
     }
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ArgumentInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ArgumentInjectionTest.java
@@ -33,4 +33,9 @@ public class ArgumentInjectionTest {
     void testValueArgumentInjected(@Value("${foo.bar}") String val) {
         assertEquals("test", val);
     }
+
+    @Test
+    void testExpressionValueArgumentInjected(@Value("#{1 + 1}") Integer val) {
+        assertEquals(2, val);
+    }
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
@@ -1,0 +1,182 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.type.Argument;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MicronautJunit5ExtensionValueParameterTest {
+
+    @Test
+    void resolveValueParameterUsesBeanResolutionContextForBeanDefinitions() throws Throwable {
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of("foo.bar", "test"))) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+
+            assertEquals("test", extension.resolveParameter(parameterContextFor(TestBean.class.getDeclaredMethod("placeholderMethod", String.class)), null));
+            assertEquals(2, extension.resolveParameter(parameterContextFor(TestBean.class.getDeclaredMethod("expressionMethod", Integer.class)), null));
+        }
+    }
+
+    @Test
+    void resolveValueParameterWrapsBeanResolutionFailures() throws Exception {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+
+            ParameterResolutionException exception = assertThrows(
+                ParameterResolutionException.class,
+                () -> extension.resolveParameter(parameterContextFor(TestBean.class.getDeclaredMethod("missingPropertyMethod", String.class)), null)
+            );
+
+            assertEquals("Unresolvable property specified to @Value: ${missing.property}", exception.getMessage());
+            assertNotNull(exception.getCause());
+        }
+    }
+
+    @Test
+    void resolveValueParameterReturnsNullForNullableExpressions() throws Throwable {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+
+            Argument<String> argument = expressionArgument(true);
+
+            assertNull(extension.invokeResolveValueParameter(
+                parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
+                argument,
+                "#{ null }"
+            ));
+        }
+    }
+
+    @Test
+    void resolveValueParameterRejectsNullExpressionsForNonNullableArguments() throws Throwable {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+            Argument<String> argument = expressionArgument(false);
+
+            ParameterResolutionException exception = assertThrows(
+                ParameterResolutionException.class,
+                () -> extension.invokeResolveValueParameter(
+                    parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
+                    argument,
+                    "#{ null }"
+                )
+            );
+
+            assertEquals("Unresolvable property specified to @Value: #{ null }", exception.getMessage());
+        }
+    }
+
+    @Test
+    void resolveValueParameterFallsBackToPlaceholderResolutionWhenBeanDefinitionIsUnavailable() throws Throwable {
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of("foo.bar", "test"))) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+
+            assertEquals(
+                "test",
+                extension.invokeResolveValueParameter(
+                    parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
+                    Argument.of(String.class),
+                    "${foo.bar}"
+                )
+            );
+        }
+    }
+
+    @Test
+    void resolveValueParameterFailsWhenFallbackCannotResolvePlaceholder() throws Exception {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+            extension.setApplicationContext(applicationContext);
+
+            ParameterResolutionException exception = assertThrows(
+                ParameterResolutionException.class,
+                () -> extension.invokeResolveValueParameter(
+                    parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
+                    Argument.of(String.class),
+                    "${missing.property}"
+                )
+            );
+
+            assertEquals("Unresolvable property specified to @Value: ${missing.property}", exception.getMessage());
+        }
+    }
+
+    private static ParameterContext parameterContextFor(Method method) {
+        ParameterContext parameterContext = mock(ParameterContext.class);
+        when(parameterContext.getDeclaringExecutable()).thenReturn(method);
+        when(parameterContext.getIndex()).thenReturn(0);
+        when(parameterContext.getParameter()).thenReturn(method.getParameters()[0]);
+        return parameterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Argument<String> expressionArgument(boolean nullable) {
+        Argument<String> argument = mock(Argument.class);
+        AnnotationMetadata annotationMetadata = mock(AnnotationMetadata.class);
+        when(argument.getAnnotationMetadata()).thenReturn(annotationMetadata);
+        when(argument.isDeclaredNullable()).thenReturn(nullable);
+        when(annotationMetadata.hasEvaluatedExpressions()).thenReturn(true);
+        when(annotationMetadata.getValue(eq(Value.class), eq(argument))).thenReturn(Optional.empty());
+        return argument;
+    }
+
+    @Singleton
+    static final class TestBean {
+        @Executable
+        void placeholderMethod(@Value("${foo.bar}") String value) {
+        }
+
+        @Executable
+        void expressionMethod(@Value("#{1 + 1}") Integer value) {
+        }
+
+        @Executable
+        void missingPropertyMethod(@Value("${missing.property}") String value) {
+        }
+    }
+
+    static final class NonBeanExecutable {
+        void placeholderMethod(String value) {
+        }
+    }
+
+    private static final class TestMicronautJunit5Extension extends MicronautJunit5Extension {
+        private void setApplicationContext(ApplicationContext applicationContext) {
+            this.applicationContext = applicationContext;
+        }
+
+        private Object invokeResolveValueParameter(ParameterContext parameterContext, Argument<?> argument, String value) throws Throwable {
+            Method method = MicronautJunit5Extension.class.getDeclaredMethod("resolveValueParameter", ParameterContext.class, Argument.class, String.class);
+            method.setAccessible(true);
+            try {
+                return method.invoke(this, parameterContext, argument, value);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
@@ -3,7 +3,7 @@ package io.micronaut.test.junit5;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Value;
-import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 import jakarta.inject.Singleton;
@@ -20,9 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class MicronautJunit5ExtensionValueParameterTest {
 
@@ -59,11 +56,9 @@ class MicronautJunit5ExtensionValueParameterTest {
             TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
             extension.setApplicationContext(applicationContext);
 
-            Argument<String> argument = expressionArgument(true);
-
             assertNull(extension.invokeResolveValueParameter(
                 parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
-                argument,
+                expressionArgument(applicationContext, "nullableExpressionMethod"),
                 "#{ null }"
             ));
         }
@@ -74,13 +69,12 @@ class MicronautJunit5ExtensionValueParameterTest {
         try (ApplicationContext applicationContext = ApplicationContext.run()) {
             TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
             extension.setApplicationContext(applicationContext);
-            Argument<String> argument = expressionArgument(false);
 
             ParameterResolutionException exception = assertThrows(
                 ParameterResolutionException.class,
                 () -> extension.invokeResolveValueParameter(
                     parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
-                    argument,
+                    expressionArgument(applicationContext, "nonNullableExpressionMethod"),
                     "#{ null }"
                 )
             );
@@ -126,22 +120,11 @@ class MicronautJunit5ExtensionValueParameterTest {
     }
 
     private static ParameterContext parameterContextFor(Method method) {
-        ParameterContext parameterContext = mock(ParameterContext.class);
-        when(parameterContext.getDeclaringExecutable()).thenReturn(method);
-        when(parameterContext.getIndex()).thenReturn(0);
-        when(parameterContext.getParameter()).thenReturn(method.getParameters()[0]);
-        return parameterContext;
+        return new TestParameterContext(method, 0);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Argument<String> expressionArgument(boolean nullable) {
-        Argument<String> argument = mock(Argument.class);
-        AnnotationMetadata annotationMetadata = mock(AnnotationMetadata.class);
-        when(argument.getAnnotationMetadata()).thenReturn(annotationMetadata);
-        when(argument.isDeclaredNullable()).thenReturn(nullable);
-        when(annotationMetadata.hasEvaluatedExpressions()).thenReturn(true);
-        when(annotationMetadata.getValue(eq(Value.class), eq(argument))).thenReturn(Optional.empty());
-        return argument;
+    private static Argument<?> expressionArgument(ApplicationContext applicationContext, String methodName) throws NoSuchMethodException {
+        return applicationContext.getExecutableMethod(TestBean.class, methodName, String.class).getArguments()[0];
     }
 
     @Singleton
@@ -157,10 +140,35 @@ class MicronautJunit5ExtensionValueParameterTest {
         @Executable
         void missingPropertyMethod(@Value("${missing.property}") String value) {
         }
+
+        @Executable
+        void nullableExpressionMethod(@Nullable @Value("#{ null }") String value) {
+        }
+
+        @Executable
+        void nonNullableExpressionMethod(@Value("#{ null }") String value) {
+        }
     }
 
     static final class NonBeanExecutable {
         void placeholderMethod(String value) {
+        }
+    }
+
+    private record TestParameterContext(java.lang.reflect.Executable declaringExecutable, int index) implements ParameterContext {
+        @Override
+        public java.lang.reflect.Parameter getParameter() {
+            return declaringExecutable.getParameters()[index];
+        }
+
+        @Override
+        public int getIndex() {
+            return index;
+        }
+
+        @Override
+        public Optional<Object> getTarget() {
+            return Optional.empty();
         }
     }
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionValueParameterTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,14 +36,15 @@ class MicronautJunit5ExtensionValueParameterTest {
     }
 
     @Test
-    void resolveValueParameterWrapsBeanResolutionFailures() throws Exception {
+    void resolveValueParameterWrapsBeanResolutionFailures() {
         try (ApplicationContext applicationContext = ApplicationContext.run()) {
             TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
             extension.setApplicationContext(applicationContext);
+            ParameterContext parameterContext = parameterContextFor(declaredMethod(TestBean.class, "missingPropertyMethod", String.class));
 
             ParameterResolutionException exception = assertThrows(
                 ParameterResolutionException.class,
-                () -> extension.resolveParameter(parameterContextFor(TestBean.class.getDeclaredMethod("missingPropertyMethod", String.class)), null)
+                () -> extension.resolveParameter(parameterContext, null)
             );
 
             assertEquals("Unresolvable property specified to @Value: ${missing.property}", exception.getMessage());
@@ -69,12 +71,14 @@ class MicronautJunit5ExtensionValueParameterTest {
         try (ApplicationContext applicationContext = ApplicationContext.run()) {
             TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
             extension.setApplicationContext(applicationContext);
+            ParameterContext parameterContext = parameterContextFor(declaredMethod(NonBeanExecutable.class, "placeholderMethod", String.class));
+            Argument<?> argument = expressionArgument(applicationContext, "nonNullableExpressionMethod");
 
             ParameterResolutionException exception = assertThrows(
                 ParameterResolutionException.class,
                 () -> extension.invokeResolveValueParameter(
-                    parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
-                    expressionArgument(applicationContext, "nonNullableExpressionMethod"),
+                    parameterContext,
+                    argument,
                     "#{ null }"
                 )
             );
@@ -101,16 +105,18 @@ class MicronautJunit5ExtensionValueParameterTest {
     }
 
     @Test
-    void resolveValueParameterFailsWhenFallbackCannotResolvePlaceholder() throws Exception {
+    void resolveValueParameterFailsWhenFallbackCannotResolvePlaceholder() {
         try (ApplicationContext applicationContext = ApplicationContext.run()) {
             TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
             extension.setApplicationContext(applicationContext);
+            ParameterContext parameterContext = parameterContextFor(declaredMethod(NonBeanExecutable.class, "placeholderMethod", String.class));
+            Argument<String> argument = Argument.of(String.class);
 
             ParameterResolutionException exception = assertThrows(
                 ParameterResolutionException.class,
                 () -> extension.invokeResolveValueParameter(
-                    parameterContextFor(NonBeanExecutable.class.getDeclaredMethod("placeholderMethod", String.class)),
-                    Argument.of(String.class),
+                    parameterContext,
+                    argument,
                     "${missing.property}"
                 )
             );
@@ -123,6 +129,14 @@ class MicronautJunit5ExtensionValueParameterTest {
         return new TestParameterContext(method, 0);
     }
 
+    private static Method declaredMethod(Class<?> type, String methodName, Class<?>... argumentTypes) {
+        try {
+            return type.getDeclaredMethod(methodName, argumentTypes);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private static Argument<?> expressionArgument(ApplicationContext applicationContext, String methodName) throws NoSuchMethodException {
         return applicationContext.getExecutableMethod(TestBean.class, methodName, String.class).getArguments()[0];
     }
@@ -131,27 +145,33 @@ class MicronautJunit5ExtensionValueParameterTest {
     static final class TestBean {
         @Executable
         void placeholderMethod(@Value("${foo.bar}") String value) {
+            // The method body is intentionally empty; the test only inspects parameter metadata.
         }
 
         @Executable
         void expressionMethod(@Value("#{1 + 1}") Integer value) {
+            // The method body is intentionally empty; the test only inspects parameter metadata.
         }
 
         @Executable
         void missingPropertyMethod(@Value("${missing.property}") String value) {
+            // The method body is intentionally empty; the test only inspects parameter metadata.
         }
 
         @Executable
         void nullableExpressionMethod(@Nullable @Value("#{ null }") String value) {
+            // The method body is intentionally empty; the test only inspects parameter metadata.
         }
 
         @Executable
         void nonNullableExpressionMethod(@Value("#{ null }") String value) {
+            // The method body is intentionally empty; the test only inspects parameter metadata.
         }
     }
 
     static final class NonBeanExecutable {
         void placeholderMethod(String value) {
+            Objects.requireNonNull(value, "value");
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve JUnit 5 test method `@Value` parameters through Micronaut's standard property value resolution path
- align `${...}` placeholder handling with regular bean field and constructor injection
- add a focused regression test for `@Value("${foo.bar}")` parameter injection

## Verification
- `./gradlew :micronaut-test-junit5:test --tests io.micronaut.test.junit5.ArgumentInjectionTest --tests io.micronaut.test.junit5.ResolveParametersTest --tests io.micronaut.test.junit5.DisableResolveParametersTest --stacktrace`

Resolves #1234