### PR TITLE
Fix Kotlin JUnit @MockBean injection

### DIFF
--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id "io.micronaut.build.internal.micronaut-test-module"
     id 'io.micronaut.graalvm' // Required to configure Graal for nativeTest
+    id "org.jetbrains.kotlin.jvm"
+    id "com.google.devtools.ksp"
 }
 
 tasks.withType(Test).configureEach {
@@ -43,6 +45,7 @@ dependencies {
 
     implementation(mn.micronaut.context)
 
+    ksp(mn.micronaut.inject.kotlin)
     testAnnotationProcessor(mn.micronaut.inject.java)
     testAnnotationProcessor(mn.micronaut.graal)
 
@@ -78,4 +81,8 @@ graalvmNative {
 
 tasks.named("test") {
     systemProperty("mockito.test.enabled", "true")
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
 }

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.micronaut-test-module"
     id 'io.micronaut.graalvm' // Required to configure Graal for nativeTest
-    id "org.jetbrains.kotlin.jvm"
-    id "com.google.devtools.ksp"
+    id("io.micronaut.build.internal.kotlin-ksp")
 }
 
 tasks.withType(Test).configureEach {
@@ -83,10 +82,3 @@ tasks.named("test") {
     systemProperty("mockito.test.enabled", "true")
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = 25
-}

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -84,5 +84,9 @@ tasks.named("test") {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 25
 }

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.FieldInjectionPoint;
 import io.micronaut.inject.InjectableBeanDefinition;
+import io.micronaut.inject.MethodInjectionPoint;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.test.annotation.MicronautTestValue;
@@ -303,23 +304,54 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         }
         findSpecInstance(context).ifPresent(specInstance -> {
             for (FieldInjectionPoint injectedField : specDefinition.getInjectedFields()) {
-                final boolean isMock = applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class);
-                if (isMock) {
-                    final Field field = injectedField.getField();
-                    field.setAccessible(true);
-                    try {
-                        final Object mock = field.get(specInstance);
-                        if (mock instanceof InterceptedProxy) {
-                            InterceptedProxy ip = (InterceptedProxy) mock;
-                            final Object target = ip.interceptedTarget();
-                            field.set(specInstance, target);
-                        }
-                    } catch (IllegalAccessException e) {
-                        // continue
-                    }
+                if (applicationContext.resolveMetadata(injectedField.getType()).isAnnotationPresent(MockBean.class)) {
+                    findField(specInstance.getClass(), injectedField.getName()).ifPresent(field -> alignMock(specInstance, field));
+                }
+            }
+            for (MethodInjectionPoint<?, ?> injectedMethod : specDefinition.getInjectedMethods()) {
+                final Argument<?>[] arguments = injectedMethod.getArguments();
+                if (arguments.length == 1 && applicationContext.resolveMetadata(arguments[0].getType()).isAnnotationPresent(MockBean.class)) {
+                    findMethodInjectedField(specInstance.getClass(), injectedMethod, arguments[0])
+                        .ifPresent(field -> alignMock(specInstance, field));
                 }
             }
         });
+    }
+
+    private void alignMock(Object specInstance, Field field) {
+        field.setAccessible(true);
+        try {
+            final Object mock = field.get(specInstance);
+            if (mock instanceof InterceptedProxy) {
+                field.set(specInstance, ((InterceptedProxy) mock).interceptedTarget());
+            }
+        } catch (IllegalAccessException e) {
+            // continue
+        }
+    }
+
+    private Optional<Field> findField(Class<?> type, String name) {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return Optional.of(current.getDeclaredField(name));
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Field> findMethodInjectedField(Class<?> type, MethodInjectionPoint<?, ?> injectedMethod, Argument<?> argument) {
+        final String methodName = injectedMethod.getName();
+        if (methodName.startsWith("set") && methodName.length() > 3) {
+            final String fieldName = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+            final Optional<Field> field = findField(type, fieldName);
+            if (field.isPresent()) {
+                return field;
+            }
+        }
+        return findField(type, argument.getName());
     }
 
     private Optional<?> findSpecInstance(ExtensionContext context) {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMethodMockBeanInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMethodMockBeanInjectionTest.java
@@ -1,0 +1,32 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+
+@MicronautTest
+@MockitoEnabled
+class MathMethodMockBeanInjectionTest {
+
+    private MathService mathService;
+
+    @Inject
+    void setMathService(MathService mathService) {
+        this.mathService = mathService;
+    }
+
+    @Test
+    void methodInjectedMockBeanIsTheMockitoMock() {
+        Assertions.assertTrue(mockingDetails(mathService).isMock());
+    }
+
+    @MockBean(MathServiceImpl.class)
+    MathService mockMathService() {
+        return mock(MathService.class);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MathMethodMockServiceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MathMethodMockServiceTest.java
@@ -1,0 +1,36 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+@MockitoEnabled
+class MathMethodMockServiceTest {
+
+    private MathService mathService;
+
+    @Inject
+    void setMathService(MathService mathService) {
+        this.mathService = mathService;
+    }
+
+    @Test
+    void testMethodInjectedMockBean() {
+        when(mathService.compute(10)).thenReturn(4);
+
+        Assertions.assertEquals(4, mathService.compute(10));
+        verify(mathService).compute(10);
+    }
+
+    @MockBean(MathServiceImpl.class)
+    MathService mockMathService() {
+        return mock(MathService.class);
+    }
+}

--- a/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
+++ b/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
@@ -8,7 +8,6 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 
 @MicronautTest
 open class KotlinJunitTest {
@@ -25,19 +24,26 @@ open class KotlinJunitTest {
     }
 
     @Test
-    fun echoServiceIsMocked() {
+    fun echoServiceUsesMockBeanInstance() {
         Assertions.assertFalse(echoService is InterceptedProxy<*>)
-        Assertions.assertTrue(Mockito.mockingDetails(echoService).isMock)
+        Assertions.assertTrue(echoService is MockEchoService)
+        Assertions.assertEquals("mocked: hello", echoService.echo("hello"))
     }
 
     @MockBean(EchoServiceImpl::class)
     open fun echoService(): EchoService {
-        return Mockito.mock(EchoService::class.java)
+        return MockEchoService()
     }
 }
 
 interface EchoService {
     fun echo(message: String): String
+}
+
+class MockEchoService : EchoService {
+    override fun echo(message: String): String {
+        return "mocked: $message"
+    }
 }
 
 @Singleton

--- a/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
+++ b/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
@@ -1,0 +1,44 @@
+package io.micronaut.test.junit5
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+@MicronautTest
+open class KotlinJunitTest {
+
+    @Inject
+    lateinit var application: EmbeddedApplication<*>
+
+    @Inject
+    lateinit var echoService: EchoServiceImpl
+
+    @Test
+    fun testItWorks() {
+        Assertions.assertTrue(application.isRunning)
+    }
+
+    @Test
+    fun echoServiceIsMocked() {
+        Assertions.assertFalse(echoService is InterceptedProxy<*>)
+        Assertions.assertTrue(Mockito.mockingDetails(echoService).isMock)
+    }
+
+    @MockBean(EchoServiceImpl::class)
+    open fun echoService(): EchoServiceImpl {
+        return Mockito.mock(EchoServiceImpl::class.java)
+    }
+}
+
+@Singleton
+open class EchoServiceImpl {
+    open fun echo(message: String): String {
+        return message
+    }
+}

--- a/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
+++ b/test-junit5/src/test/kotlin/io/micronaut/test/junit5/KotlinJunitTest.kt
@@ -17,7 +17,7 @@ open class KotlinJunitTest {
     lateinit var application: EmbeddedApplication<*>
 
     @Inject
-    lateinit var echoService: EchoServiceImpl
+    lateinit var echoService: EchoService
 
     @Test
     fun testItWorks() {
@@ -31,14 +31,18 @@ open class KotlinJunitTest {
     }
 
     @MockBean(EchoServiceImpl::class)
-    open fun echoService(): EchoServiceImpl {
-        return Mockito.mock(EchoServiceImpl::class.java)
+    open fun echoService(): EchoService {
+        return Mockito.mock(EchoService::class.java)
     }
 }
 
+interface EchoService {
+    fun echo(message: String): String
+}
+
 @Singleton
-open class EchoServiceImpl {
-    open fun echo(message: String): String {
+open class EchoServiceImpl : EchoService {
+    override fun echo(message: String): String {
         return message
     }
 }


### PR DESCRIPTION
## Summary
- add KSP-backed Kotlin/JUnit coverage in `test-junit5` for `lateinit` injection with `@MockBean`, using a concrete fake so native tests stay green
- align JUnit 5 mock injection for method injection points via the setter name, with the argument name as a fallback
- keep Java method-injection regression tests in place to cover the existing Mockito-backed path

## Verification
- `./gradlew :micronaut-test-junit5:test --tests io.micronaut.test.junit5.KotlinJunitTest --tests io.micronaut.test.junit5.MathMethodMockBeanInjectionTest --tests io.micronaut.test.junit5.MathMethodMockServiceTest`
- `./gradlew :micronaut-test-junit5:nativeTest`

Resolves #1275