### PR TITLE
Report duplicate @Property names in a single property source

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -63,10 +63,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Abstract base class for both JUnit 5 and Spock.
@@ -288,6 +290,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 new ClassClassPathResourceLoader(testClass)
             ));
             final List<Property> ps = AnnotationUtils.findRepeatableAnnotations(testClass, Property.class);
+            validateUniquePropertyNames(ps, "test class " + testClass.getName());
             for (Property property : ps) {
                 testProperties.put(property.name(), property.value());
             }
@@ -417,6 +420,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     protected void beforeEach(C context, @Nullable Object testInstance, @Nullable AnnotatedElement method, List<Property> propertyAnnotations) {
         if (method != null) {
             if (propertyAnnotations != null && !propertyAnnotations.isEmpty()) {
+                validateUniquePropertyNames(propertyAnnotations, "test method " + method);
                 for (Property property : propertyAnnotations) {
                     final String name = property.name();
                     oldValues.put(name,
@@ -453,6 +457,16 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 }
                 applicationContext.inject(testInstance);
                 alignMocks(context, testInstance);
+            }
+        }
+    }
+
+    private void validateUniquePropertyNames(List<Property> properties, String propertySourceDescription) {
+        Set<String> names = new HashSet<>(properties.size());
+        for (Property property : properties) {
+            String name = property.name();
+            if (!names.add(name)) {
+                throw new IllegalStateException("Duplicate @Property name [" + name + "] declared on " + propertySourceDescription);
             }
         }
     }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/DuplicatePropertyNameValidationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/DuplicatePropertyNameValidationTest.java
@@ -5,7 +5,7 @@ import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -18,26 +18,33 @@ class DuplicatePropertyNameValidationTest {
     void rejectsDuplicateClassLevelProperties() {
         TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-            () -> extension.start(DuplicateClassLevelPropertyTest.class));
+        try {
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> extension.start(DuplicateClassLevelPropertyFixture.class));
 
-        assertEquals(
-            "Duplicate @Property name [test.property] declared on test class io.micronaut.test.junit5.DuplicateClassLevelPropertyTest",
-            exception.getMessage()
-        );
+            assertEquals(
+                "Duplicate @Property name [test.property] declared on test class io.micronaut.test.junit5.DuplicateClassLevelPropertyFixture",
+                exception.getMessage()
+            );
+        } finally {
+            extension.stop();
+        }
     }
 
     @Test
     void rejectsDuplicateMethodLevelProperties() {
         TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
-        extension.start(UniqueClassLevelPropertyTest.class);
+        extension.start(UniqueClassLevelPropertyFixture.class);
 
         try {
             IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> extension.beforeEach("duplicateMethodLevelProperty"));
+                () -> extension.beforeEach(
+                    "public void io.micronaut.test.junit5.UniqueClassLevelPropertyFixture.duplicateMethodLevelProperty()",
+                    DuplicateMethodLevelPropertySource.class
+                ));
 
             assertEquals(
-                "Duplicate @Property name [test.property] declared on test method void io.micronaut.test.junit5.UniqueClassLevelPropertyTest.duplicateMethodLevelProperty()",
+                "Duplicate @Property name [test.property] declared on test method public void io.micronaut.test.junit5.UniqueClassLevelPropertyFixture.duplicateMethodLevelProperty()",
                 exception.getMessage()
             );
         } finally {
@@ -48,10 +55,13 @@ class DuplicatePropertyNameValidationTest {
     @Test
     void allowsMethodLevelOverrideOfClassLevelProperty() {
         TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
-        extension.start(UniqueClassLevelPropertyTest.class);
+        extension.start(UniqueClassLevelPropertyFixture.class);
 
         try {
-            assertDoesNotThrow(() -> extension.beforeEach("overrideClassLevelProperty"));
+            assertDoesNotThrow(() -> extension.beforeEach(
+                "public void io.micronaut.test.junit5.UniqueClassLevelPropertyFixture.overrideClassLevelProperty()",
+                OverrideMethodLevelPropertySource.class
+            ));
         } finally {
             extension.stop();
         }
@@ -62,13 +72,41 @@ class DuplicatePropertyNameValidationTest {
             beforeClass(null, testClass, buildMicronautTestValue(testClass));
         }
 
-        void beforeEach(String methodName) throws NoSuchMethodException {
-            Method method = UniqueClassLevelPropertyTest.class.getDeclaredMethod(methodName);
-            beforeEach(null, null, method, Arrays.asList(method.getAnnotationsByType(Property.class)));
+        void beforeEach(String methodDescription, Class<?> propertySource) {
+            beforeEach(
+                null,
+                null,
+                namedMethod(methodDescription),
+                Arrays.asList(propertySource.getAnnotationsByType(Property.class))
+            );
         }
 
         void stop() {
             afterClass(null);
+        }
+
+        private AnnotatedElement namedMethod(String methodDescription) {
+            return new AnnotatedElement() {
+                @Override
+                public <T extends java.lang.annotation.Annotation> T getAnnotation(Class<T> annotationClass) {
+                    return null;
+                }
+
+                @Override
+                public java.lang.annotation.Annotation[] getAnnotations() {
+                    return new java.lang.annotation.Annotation[0];
+                }
+
+                @Override
+                public java.lang.annotation.Annotation[] getDeclaredAnnotations() {
+                    return new java.lang.annotation.Annotation[0];
+                }
+
+                @Override
+                public String toString() {
+                    return methodDescription;
+                }
+            };
         }
     }
 }
@@ -76,19 +114,19 @@ class DuplicatePropertyNameValidationTest {
 @MicronautTest
 @Property(name = "test.property", value = "first")
 @Property(name = "test.property", value = "second")
-class DuplicateClassLevelPropertyTest {
+class DuplicateClassLevelPropertyFixture {
 }
 
 @MicronautTest
 @Property(name = "test.property", value = "class-level")
-class UniqueClassLevelPropertyTest {
+class UniqueClassLevelPropertyFixture {
+}
 
-    @Property(name = "test.property", value = "first")
-    @Property(name = "test.property", value = "second")
-    void duplicateMethodLevelProperty() {
-    }
+@Property(name = "test.property", value = "first")
+@Property(name = "test.property", value = "second")
+class DuplicateMethodLevelPropertySource {
+}
 
-    @Property(name = "test.property", value = "method-level")
-    void overrideClassLevelProperty() {
-    }
+@Property(name = "test.property", value = "method-level")
+class OverrideMethodLevelPropertySource {
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/DuplicatePropertyNameValidationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/DuplicatePropertyNameValidationTest.java
@@ -1,0 +1,94 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DuplicatePropertyNameValidationTest {
+
+    @Test
+    void rejectsDuplicateClassLevelProperties() {
+        TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> extension.start(DuplicateClassLevelPropertyTest.class));
+
+        assertEquals(
+            "Duplicate @Property name [test.property] declared on test class io.micronaut.test.junit5.DuplicateClassLevelPropertyTest",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    void rejectsDuplicateMethodLevelProperties() {
+        TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+        extension.start(UniqueClassLevelPropertyTest.class);
+
+        try {
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> extension.beforeEach("duplicateMethodLevelProperty"));
+
+            assertEquals(
+                "Duplicate @Property name [test.property] declared on test method void io.micronaut.test.junit5.UniqueClassLevelPropertyTest.duplicateMethodLevelProperty()",
+                exception.getMessage()
+            );
+        } finally {
+            extension.stop();
+        }
+    }
+
+    @Test
+    void allowsMethodLevelOverrideOfClassLevelProperty() {
+        TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+        extension.start(UniqueClassLevelPropertyTest.class);
+
+        try {
+            assertDoesNotThrow(() -> extension.beforeEach("overrideClassLevelProperty"));
+        } finally {
+            extension.stop();
+        }
+    }
+
+    static final class TestMicronautJunit5Extension extends MicronautJunit5Extension {
+        void start(Class<?> testClass) {
+            beforeClass(null, testClass, buildMicronautTestValue(testClass));
+        }
+
+        void beforeEach(String methodName) throws NoSuchMethodException {
+            Method method = UniqueClassLevelPropertyTest.class.getDeclaredMethod(methodName);
+            beforeEach(null, null, method, Arrays.asList(method.getAnnotationsByType(Property.class)));
+        }
+
+        void stop() {
+            afterClass(null);
+        }
+    }
+}
+
+@MicronautTest
+@Property(name = "test.property", value = "first")
+@Property(name = "test.property", value = "second")
+class DuplicateClassLevelPropertyTest {
+}
+
+@MicronautTest
+@Property(name = "test.property", value = "class-level")
+class UniqueClassLevelPropertyTest {
+
+    @Property(name = "test.property", value = "first")
+    @Property(name = "test.property", value = "second")
+    void duplicateMethodLevelProperty() {
+    }
+
+    @Property(name = "test.property", value = "method-level")
+    void overrideClassLevelProperty() {
+    }
+}


### PR DESCRIPTION
## Summary
- reject duplicate `@Property` names declared within the same class-level property source
- reject duplicate `@Property` names declared within the same method-level property source
- make the JUnit 5 regression helper native-safe and Sonar-clean while preserving the class-vs-method override coverage

## Verification
- `./gradlew :micronaut-test-junit5:test --tests io.micronaut.test.junit5.DuplicatePropertyNameValidationTest`
- `./gradlew :micronaut-test-junit5:nativeTest`

Resolves #1232