### PR TITLE
Fix JUnit 5 TestPropertyProvider lifecycle handling

### DIFF
--- a/src/main/docs/guide/junit5/junit5DefiningAdditionalTestSpecificProperties.adoc
+++ b/src/main/docs/guide/junit5/junit5DefiningAdditionalTestSpecificProperties.adoc
@@ -32,4 +32,4 @@ For example:
 include::{junit5tests}/PropertySourceMapTest.java[]
 ----
 
-NOTE: When using `TestPropertyProvider` your test must be declared with JUnit's `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` annotation.
+NOTE: When using `TestPropertyProvider` your test must use JUnit's `PER_CLASS` test instance lifecycle, for example with `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`. The properties are resolved from the test instance before the Micronaut context starts.

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -78,16 +79,23 @@ import java.util.Optional;
  */
 public class MicronautJunit5Extension extends AbstractMicronautExtension<ExtensionContext> implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, ExecutionCondition, BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver, InvocationInterceptor {
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MicronautJunit5Extension.class);
+    private static final String TEST_PROPERTY_PROVIDER_LIFECYCLE_MESSAGE = "Tests that implement TestPropertyProvider must use the PER_CLASS test instance lifecycle.";
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
         final Class<?> testClass = extensionContext.getRequiredTestClass();
+        final TestInstance.Lifecycle testInstanceLifecycle = extensionContext.getTestInstanceLifecycle().orElse(TestInstance.Lifecycle.PER_METHOD);
+        if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
+            if (testInstanceLifecycle != TestInstance.Lifecycle.PER_CLASS) {
+                throw new ExtensionConfigurationException(TEST_PROPERTY_PROVIDER_LIFECYCLE_MESSAGE);
+            }
+            extensionContext.getRequiredTestInstance();
+        }
         MicronautTestValue micronautTestValue = buildMicronautTestValue(testClass);
         beforeClass(extensionContext, testClass, micronautTestValue);
         getStore(extensionContext).put(ApplicationContext.class, applicationContext);
         if (specDefinition != null) {
-            TestInstance ti = AnnotationSupport.findAnnotation(testClass, TestInstance.class).orElse(null);
-            if (ti != null && ti.value() == TestInstance.Lifecycle.PER_CLASS) {
+            if (testInstanceLifecycle == TestInstance.Lifecycle.PER_CLASS) {
                 Object testInstance = extensionContext.getRequiredTestInstance();
                 if (specDefinition instanceof ProxyBeanDefinition<?>) {
                     // Proxy bean is not going to resolve bean definition, we need a small hack

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TestPropertyProviderLifecycleValidationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TestPropertyProviderLifecycleValidationTest.java
@@ -1,0 +1,45 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import io.micronaut.test.support.TestPropertyProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestPropertyProviderLifecycleValidationTest {
+
+    @Test
+    void testPropertyProviderRequiresPerClassLifecycle() throws Exception {
+        ExtensionContext extensionContext = mock(ExtensionContext.class);
+        doReturn(MisconfiguredTestPropertyProviderLifecycleSubject.class).when(extensionContext).getRequiredTestClass();
+        when(extensionContext.getTestInstanceLifecycle()).thenReturn(Optional.of(TestInstance.Lifecycle.PER_METHOD));
+
+        ExtensionConfigurationException e = assertThrows(
+            ExtensionConfigurationException.class,
+            () -> new MicronautJunit5Extension().beforeAll(extensionContext)
+        );
+
+        assertEquals("Tests that implement TestPropertyProvider must use the PER_CLASS test instance lifecycle.", e.getMessage());
+    }
+
+    @MicronautTest
+    static class MisconfiguredTestPropertyProviderLifecycleSubject implements TestPropertyProvider {
+
+        @Override
+        public @NonNull Map<String, String> getProperties() {
+            return Map.of("foo.bar", "one");
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TestPropertyProviderLifecycleValidationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TestPropertyProviderLifecycleValidationTest.java
@@ -9,22 +9,21 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class TestPropertyProviderLifecycleValidationTest {
 
     @Test
     void testPropertyProviderRequiresPerClassLifecycle() throws Exception {
-        ExtensionContext extensionContext = mock(ExtensionContext.class);
-        doReturn(MisconfiguredTestPropertyProviderLifecycleSubject.class).when(extensionContext).getRequiredTestClass();
-        when(extensionContext.getTestInstanceLifecycle()).thenReturn(Optional.of(TestInstance.Lifecycle.PER_METHOD));
+        ExtensionContext extensionContext = extensionContext(
+            MisconfiguredTestPropertyProviderLifecycleSubject.class,
+            TestInstance.Lifecycle.PER_METHOD
+        );
 
         ExtensionConfigurationException e = assertThrows(
             ExtensionConfigurationException.class,
@@ -32,6 +31,21 @@ class TestPropertyProviderLifecycleValidationTest {
         );
 
         assertEquals("Tests that implement TestPropertyProvider must use the PER_CLASS test instance lifecycle.", e.getMessage());
+    }
+
+    private static ExtensionContext extensionContext(Class<?> testClass, TestInstance.Lifecycle lifecycle) {
+        return (ExtensionContext) Proxy.newProxyInstance(
+            ExtensionContext.class.getClassLoader(),
+            new Class<?>[]{ExtensionContext.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getRequiredTestClass" -> testClass;
+                case "getTestInstanceLifecycle" -> Optional.of(lifecycle);
+                case "toString" -> "TestExtensionContext[" + testClass.getName() + "]";
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "equals" -> proxy == args[0];
+                default -> throw new UnsupportedOperationException("Unexpected ExtensionContext method: " + method.getName());
+            }
+        );
     }
 
     @MicronautTest


### PR DESCRIPTION
This ensures JUnit 5 test classes that implement `TestPropertyProvider` resolve properties from the actual PER_CLASS test instance before the Micronaut context starts.

It also removes Mockito from the lifecycle validation test so the regression coverage stays CI-friendly.

Resolves #1233
