### PR TITLE
Limit Micronaut test context parallelism

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -43,6 +43,19 @@ EmbeddedServer server //refers to the server that was started up for this test s
 ApplicationContext context //refers to the current application context within the scope of the test
 ----
 
+### Limiting Active Test Contexts
+
+If your build runs tests in parallel and each `@MicronautTest` starts its own datasource, connection pool, or other expensive shared resource, you can limit how many Micronaut test application contexts are active at the same time with the `micronaut.test.context.parallelism` JVM system property.
+
+The value must be greater than `0` and applies across Micronaut Test integrations such as JUnit 5, Spock, and Kotest.
+
+[source,groovy]
+----
+test {
+    systemProperty "micronaut.test.context.parallelism", "1"
+}
+----
+
 ### Eager Singleton Initialization
 
 If you enable https://docs.micronaut.io/latest/guide/index.html#eagerInit[eager singleton initialization] in your application, the Micronaut Framework eagerly initializes all singletons at startup time. This can be useful for applications that need to perform some initialization at startup time, such as registering a bean with a third party library.

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -102,6 +102,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     private ApplicationContextBuilder builder = ApplicationContext.builder();
     private List<TestExecutionListener> listeners;
     private List<TestMethodInterceptor<Object>> interceptors;
+    private TestContextParallelismLimiter.Lease contextParallelismLease;
 
     /**
      * @return True if there are interceptors
@@ -274,118 +275,133 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
      */
     protected void beforeClass(C context, Class<?> testClass, @Nullable MicronautTestValue testAnnotationValue) {
         if (testAnnotationValue != null) {
-            Class<? extends ApplicationContextBuilder>[] cb = testAnnotationValue.contextBuilder();
-            if (ArrayUtils.isNotEmpty(cb)) {
-                this.builder = InstantiationUtils.instantiate(cb[0]);
-            }
-            this.testAnnotationValue = testAnnotationValue;
-            this.testClass = testClass;
+            contextParallelismLease = TestContextParallelismLimiter.acquire();
+            boolean success = false;
+            try {
+                Class<? extends ApplicationContextBuilder>[] cb = testAnnotationValue.contextBuilder();
+                if (ArrayUtils.isNotEmpty(cb)) {
+                    this.builder = InstantiationUtils.instantiate(cb[0]);
+                }
+                this.testAnnotationValue = testAnnotationValue;
+                this.testClass = testClass;
 
-            final Package aPackage = testClass.getPackage();
-            builder.packages(aPackage.getName());
-            builder.resourceResolver(CombinedClassPathResourceLoader.of(
-                ClassPathResourceLoader.defaultLoader(null),
-                new ClassClassPathResourceLoader(testClass)
-            ));
-            final List<Property> ps = AnnotationUtils.findRepeatableAnnotations(testClass, Property.class);
-            for (Property property : ps) {
-                testProperties.put(property.name(), property.value());
-            }
+                final Package aPackage = testClass.getPackage();
+                builder.packages(aPackage.getName());
+                builder.resourceResolver(CombinedClassPathResourceLoader.of(
+                    ClassPathResourceLoader.defaultLoader(null),
+                    new ClassClassPathResourceLoader(testClass)
+                ));
+                final List<Property> ps = AnnotationUtils.findRepeatableAnnotations(testClass, Property.class);
+                for (Property property : ps) {
+                    testProperties.put(property.name(), property.value());
+                }
 
-            testProperties.put(TestActiveCondition.ACTIVE_SPEC_CLAZZ, testClass);
-            testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotationValue.rollback()));
-            testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
-            testProperties.put(TEST_TRANSACTION_MODE, String.valueOf(testAnnotationValue.transactionMode()));
-            testProperties.put(Environment.DEDUCE_ENVIRONMENT_PROPERTY, String.valueOf(testAnnotationValue.deduceEnvironment()));
-            final Class<?> application = testAnnotationValue.application();
-            if (application != void.class) {
-                builder.mainClass(application);
-            }
-            String[] environments = testAnnotationValue.environments();
-            if (environments.length == 0) {
-                environments = new String[]{"test"};
-            }
-            builder.packages(testAnnotationValue.packages())
-                .environments(environments);
-            if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
-                resolveTestProperties(context, testAnnotationValue, testProperties);
-            }
-            PropertySource testPropertySource = PropertySource.of(
-                TEST_PROPERTY_SOURCE,
-                testProperties
-            );
-            builder.propertySources(testPropertySource);
+                testProperties.put(TestActiveCondition.ACTIVE_SPEC_CLAZZ, testClass);
+                testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotationValue.rollback()));
+                testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
+                testProperties.put(TEST_TRANSACTION_MODE, String.valueOf(testAnnotationValue.transactionMode()));
+                testProperties.put(Environment.DEDUCE_ENVIRONMENT_PROPERTY, String.valueOf(testAnnotationValue.deduceEnvironment()));
+                final Class<?> application = testAnnotationValue.application();
+                if (application != void.class) {
+                    builder.mainClass(application);
+                }
+                String[] environments = testAnnotationValue.environments();
+                if (environments.length == 0) {
+                    environments = new String[]{"test"};
+                }
+                builder.packages(testAnnotationValue.packages())
+                    .environments(environments);
+                if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
+                    resolveTestProperties(context, testAnnotationValue, testProperties);
+                }
+                PropertySource testPropertySource = PropertySource.of(
+                    TEST_PROPERTY_SOURCE,
+                    testProperties
+                );
+                builder.propertySources(testPropertySource);
 
-            builder.propertySourcesLocator(new PropertySourcesLocator() {
-                @Override
-                public Collection<PropertySource> load(Environment environment) {
-                    List<PropertySource> loadedPropertySources = new ArrayList<>();
-                    for (String propertySourceName : testAnnotationValue.propertySources()) {
-                        String ext = NameUtils.extension(propertySourceName);
-                        if (StringUtils.isEmpty(ext)) {
-                            continue;
-                        }
-                        for (PropertySourceLoader loader : environment.getPropertySourceLoaders()) {
-                            if (!loader.getExtensions().contains(ext)) {
+                builder.propertySourcesLocator(new PropertySourcesLocator() {
+                    @Override
+                    public Collection<PropertySource> load(Environment environment) {
+                        List<PropertySource> loadedPropertySources = new ArrayList<>();
+                        for (String propertySourceName : testAnnotationValue.propertySources()) {
+                            String ext = NameUtils.extension(propertySourceName);
+                            if (StringUtils.isEmpty(ext)) {
                                 continue;
                             }
-
-                            environment.getResourceAsStream(propertySourceName).ifPresent(inputStream -> {
-                                try (inputStream) {
-                                    String filename = NameUtils.filename(propertySourceName);
-                                    try {
-                                        loadedPropertySources.add(PropertySource.of(filename, loader.read(filename, inputStream)));
-                                    } catch (IOException e) {
-                                        throw new RuntimeException("Error loading property source reference for @MicronautTest: " + filename);
-                                    }
-                                } catch (IOException e) {
-                                    // ignore
+                            for (PropertySourceLoader loader : environment.getPropertySourceLoaders()) {
+                                if (!loader.getExtensions().contains(ext)) {
+                                    continue;
                                 }
-                            });
-                        }
-                    }
-                    List<TestPropertyProviderFactory> testPropertyProviderFactories = SoftServiceLoader.load(TestPropertyProviderFactory.class).collectAll();
-                    if (!testPropertyProviderFactories.isEmpty()) {
-                        var props = new HashMap<>(testProperties);
-                        for (PropertySource source : environment.getPropertySources()) {
-                            for (String key : source) {
-                                props.put(key, source.get(key));
-                            }
-                        }
-                        for (PropertySource source : loadedPropertySources) {
-                            for (String key : source) {
-                                props.put(key, source.get(key));
-                            }
-                        }
-                        for (TestPropertyProviderFactory factory : testPropertyProviderFactories) {
-                            var provider = factory.create(Collections.unmodifiableMap(props), testClass);
-                            testProperties.putAll(provider.get());
-                        }
-                    }
-                    if (!testProperties.isEmpty()) {
-                        loadedPropertySources.add(PropertySource.of(TEST_PROPERTY_SOURCE, testProperties));
-                    }
-                    return loadedPropertySources;
-                }
-            });
 
-            postProcessBuilder(builder);
-            this.applicationContext = builder.build();
-            startApplicationContext();
-            specDefinition = applicationContext.findBeanDefinition(testClass).orElse(null);
-            if (specDefinition instanceof ProxyBeanDefinition<?>) {
-                interceptors = new ArrayList<>(interceptors);
-                interceptors.add(new MicronautIntercepted(
-                    specDefinition,
-                    applicationContext.getBean(InterceptorRegistry.class),
-                    new ArrayList<>(applicationContext.getBeanRegistrations(Argument.of(Interceptor.class), null))
-                ));
+                                environment.getResourceAsStream(propertySourceName).ifPresent(inputStream -> {
+                                    try (inputStream) {
+                                        String filename = NameUtils.filename(propertySourceName);
+                                        try {
+                                            loadedPropertySources.add(PropertySource.of(filename, loader.read(filename, inputStream)));
+                                        } catch (IOException e) {
+                                            throw new RuntimeException("Error loading property source reference for @MicronautTest: " + filename);
+                                        }
+                                    } catch (IOException e) {
+                                        // ignore
+                                    }
+                                });
+                            }
+                        }
+                        List<TestPropertyProviderFactory> testPropertyProviderFactories = SoftServiceLoader.load(TestPropertyProviderFactory.class).collectAll();
+                        if (!testPropertyProviderFactories.isEmpty()) {
+                            var props = new HashMap<>(testProperties);
+                            for (PropertySource source : environment.getPropertySources()) {
+                                for (String key : source) {
+                                    props.put(key, source.get(key));
+                                }
+                            }
+                            for (PropertySource source : loadedPropertySources) {
+                                for (String key : source) {
+                                    props.put(key, source.get(key));
+                                }
+                            }
+                            for (TestPropertyProviderFactory factory : testPropertyProviderFactories) {
+                                var provider = factory.create(Collections.unmodifiableMap(props), testClass);
+                                testProperties.putAll(provider.get());
+                            }
+                        }
+                        if (!testProperties.isEmpty()) {
+                            loadedPropertySources.add(PropertySource.of(TEST_PROPERTY_SOURCE, testProperties));
+                        }
+                        return loadedPropertySources;
+                    }
+                });
+
+                postProcessBuilder(builder);
+                this.applicationContext = builder.build();
+                startApplicationContext();
+                specDefinition = applicationContext.findBeanDefinition(testClass).orElse(null);
+                if (specDefinition instanceof ProxyBeanDefinition<?>) {
+                    interceptors = new ArrayList<>(interceptors);
+                    interceptors.add(new MicronautIntercepted(
+                        specDefinition,
+                        applicationContext.getBean(InterceptorRegistry.class),
+                        new ArrayList<>(applicationContext.getBeanRegistrations(Argument.of(Interceptor.class), null))
+                    ));
+                }
+                if (testAnnotationValue.startApplication() && applicationContext.containsBean(EmbeddedApplication.class)) {
+                    embeddedApplication = applicationContext.getBean(EmbeddedApplication.class);
+                    embeddedApplication.start();
+                }
+                refreshScope = applicationContext.findBean(RefreshScope.class).orElse(null);
+                success = true;
+            } finally {
+                if (!success) {
+                    stopEmbeddedApplication();
+                    if (applicationContext != null && applicationContext.isRunning()) {
+                        applicationContext.stop();
+                    }
+                    embeddedApplication = null;
+                    applicationContext = null;
+                    releaseContextParallelismLease();
+                }
             }
-            if (testAnnotationValue.startApplication() && applicationContext.containsBean(EmbeddedApplication.class)) {
-                embeddedApplication = applicationContext.getBean(EmbeddedApplication.class);
-                embeddedApplication.start();
-            }
-            refreshScope = applicationContext.findBean(RefreshScope.class).orElse(null);
         }
     }
 
@@ -463,12 +479,16 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
      * @param context the context
      */
     protected void afterClass(C context) {
-        stopEmbeddedApplication();
-        if (applicationContext != null && applicationContext.isRunning()) {
-            applicationContext.stop();
+        try {
+            stopEmbeddedApplication();
+            if (applicationContext != null && applicationContext.isRunning()) {
+                applicationContext.stop();
+            }
+            embeddedApplication = null;
+            applicationContext = null;
+        } finally {
+            releaseContextParallelismLease();
         }
-        embeddedApplication = null;
-        applicationContext = null;
     }
 
     /**
@@ -531,6 +551,13 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     private void stopEmbeddedApplication() {
         if (embeddedApplication != null) {
             embeddedApplication.stop();
+        }
+    }
+
+    private void releaseContextParallelismLease() {
+        if (contextParallelismLease != null) {
+            contextParallelismLease.release();
+            contextParallelismLease = null;
         }
     }
 

--- a/test-core/src/main/java/io/micronaut/test/extensions/TestContextParallelismLimiter.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/TestContextParallelismLimiter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions;
+
+import io.micronaut.core.annotation.Nullable;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
+
+final class TestContextParallelismLimiter {
+
+    static final String CONTEXT_PARALLELISM_PROPERTY = "micronaut.test.context.parallelism";
+
+    private static final ConcurrentMap<Integer, Semaphore> SEMAPHORES = new ConcurrentHashMap<>();
+
+    private TestContextParallelismLimiter() {
+    }
+
+    @Nullable
+    static Lease acquire() {
+        Integer maxActiveContexts = Integer.getInteger(CONTEXT_PARALLELISM_PROPERTY);
+        if (maxActiveContexts == null) {
+            return null;
+        }
+        if (maxActiveContexts < 1) {
+            throw new IllegalArgumentException("System property '" + CONTEXT_PARALLELISM_PROPERTY + "' must be greater than zero");
+        }
+        Semaphore semaphore = SEMAPHORES.computeIfAbsent(maxActiveContexts, permits -> new Semaphore(permits, true));
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for a Micronaut test context permit", e);
+        }
+        return semaphore::release;
+    }
+
+    @FunctionalInterface
+    interface Lease {
+        void release();
+    }
+}

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testAnnotationProcessor(mn.micronaut.graal)
 
     testImplementation(libs.managed.junit.jupiter.params)
+    testImplementation(libs.managed.junit.platform.launcher)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
     testImplementation(libs.managed.mockito.junit.jupiter)
@@ -60,7 +61,6 @@ dependencies {
     testRuntimeOnly(mnSql.h2)
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     testRuntimeOnly(libs.managed.junit.jupiter.engine)
-    testRuntimeOnly(libs.managed.junit.platform.launcher)
     testRuntimeOnly(testFixtures(projects.micronautTestCore))
 }
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautTestContextParallelismTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautTestContextParallelismTest.java
@@ -1,0 +1,151 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+class MicronautTestContextParallelismTest {
+
+    private static final String CONTEXT_PARALLELISM = "micronaut.test.context.parallelism";
+
+    @AfterEach
+    void clearState() {
+        System.clearProperty(CONTEXT_PARALLELISM);
+        ParallelContextProbe.reset();
+    }
+
+    @Test
+    void limitsActiveMicronautTestContextsAcrossParallelJUnitClasses() {
+        System.setProperty(CONTEXT_PARALLELISM, "1");
+
+        TestExecutionSummary summary = executeInParallel(
+            selectClass(ParallelContextMicronautTestOne.class),
+            selectClass(ParallelContextMicronautTestTwo.class)
+        );
+
+        assertTrue(summary.failures().isEmpty(), () -> "Expected no failures but saw: " + summary.failures());
+        assertTrue(ParallelContextProbe.maxActiveContexts() <= 1,
+            () -> "Expected at most one active context, saw " + ParallelContextProbe.maxActiveContexts());
+    }
+
+    private static TestExecutionSummary executeInParallel(DiscoverySelector... selectors) {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+            .selectors(selectors)
+            .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.default", "same_thread")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
+            .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
+            .configurationParameter("junit.jupiter.execution.parallel.config.fixed.parallelism", "2")
+            .build();
+
+        Launcher launcher = LauncherFactory.create();
+        TestExecutionSummary summary = new TestExecutionSummary();
+        launcher.registerTestExecutionListeners(summary);
+        launcher.execute(request);
+        return summary;
+    }
+
+    private static final class TestExecutionSummary implements TestExecutionListener {
+        private final List<String> failures = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            testExecutionResult.getThrowable().ifPresent(throwable ->
+                failures.add(testIdentifier.getDisplayName() + ": " + throwable.getMessage())
+            );
+        }
+
+        List<String> failures() {
+            return failures;
+        }
+    }
+}
+
+@MicronautTest
+class ParallelContextMicronautTestOne {
+
+    @Inject
+    ParallelContextVerifier verifier;
+
+    @Test
+    void testContextStarts() {
+        assertTrue(verifier.isPresent());
+    }
+}
+
+@MicronautTest
+class ParallelContextMicronautTestTwo {
+
+    @Inject
+    ParallelContextVerifier verifier;
+
+    @Test
+    void testContextStarts() {
+        assertTrue(verifier.isPresent());
+    }
+}
+
+@Context
+@Singleton
+class ParallelContextProbe {
+    private static final AtomicInteger ACTIVE_CONTEXTS = new AtomicInteger();
+    private static final AtomicInteger MAX_ACTIVE_CONTEXTS = new AtomicInteger();
+
+    ParallelContextProbe() {
+        int activeContexts = ACTIVE_CONTEXTS.incrementAndGet();
+        MAX_ACTIVE_CONTEXTS.accumulateAndGet(activeContexts, Math::max);
+        if (activeContexts > 1) {
+            throw new IllegalStateException("Detected " + activeContexts + " active Micronaut test contexts");
+        }
+        try {
+            Thread.sleep(Duration.ofMillis(250));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while simulating slow startup", e);
+        }
+    }
+
+    @PreDestroy
+    void close() {
+        ACTIVE_CONTEXTS.decrementAndGet();
+    }
+
+    static int maxActiveContexts() {
+        return MAX_ACTIVE_CONTEXTS.get();
+    }
+
+    static void reset() {
+        ACTIVE_CONTEXTS.set(0);
+        MAX_ACTIVE_CONTEXTS.set(0);
+    }
+}
+
+@Singleton
+@Requires(beans = ParallelContextProbe.class)
+class ParallelContextVerifier {
+
+    boolean isPresent() {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared limiter for active Micronaut test application contexts
- cover the regression with a parallel JUnit 5 test that fails on clean 5.0.x
- document the `micronaut.test.context.parallelism` system property for parallel test suites

Resolves #1202