### PR TITLE
Fix Spock cleanupSpec HTTP client lifecycle

### DIFF
--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -115,11 +115,19 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
         );
 
         spec.addCleanupSpecInterceptor(invocation -> {
-            afterTestClass(buildContext(invocation, null));
-            afterClass(invocation);
-
-            invocation.proceed();
-            singletonMocks.clear();
+            try {
+                invocation.proceed();
+            } finally {
+                try {
+                    afterTestClass(buildContext(invocation, null));
+                } finally {
+                    try {
+                        afterClass(invocation);
+                    } finally {
+                        singletonMocks.clear();
+                    }
+                }
+            }
         });
 
         spec.addSetupInterceptor(invocation -> {

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecHttpsRequestSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecHttpsRequestSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+@MicronautTest
+@Issue("https://github.com/micronaut-projects/micronaut-test/issues/1191")
+@Property(name = "micronaut.http.client.ssl.insecure-trust-all-certificates", value = "true")
+class CleanupSpecHttpsRequestSpec extends Specification {
+
+    @Shared
+    private static final EmbeddedServer EXTERNAL_SERVER = ApplicationContext.run(
+        EmbeddedServer,
+        [
+            "micronaut.server.port": -1,
+            "micronaut.server.ssl.enabled": true,
+            "micronaut.server.ssl.build-self-signed": true
+        ]
+    )
+
+    @Inject
+    @Shared
+    @Client("/")
+    HttpClient client
+
+    void cleanupSpec() {
+        try {
+            assert client.toBlocking().retrieve(HttpRequest.GET("${EXTERNAL_SERVER.getURL()}/test"), String) == "orignal"
+        } finally {
+            EXTERNAL_SERVER.stop()
+        }
+    }
+
+    void "shared client remains usable during cleanupSpec"() {
+        expect:
+        client.toBlocking().retrieve(HttpRequest.GET("${EXTERNAL_SERVER.getURL()}/test"), String) == "orignal"
+    }
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecInjectedHttpClientHttpsRequestSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecInjectedHttpClientHttpsRequestSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+@MicronautTest
+@Issue("https://github.com/micronaut-projects/micronaut-test/issues/1191")
+@Property(name = "micronaut.http.client.ssl.insecure-trust-all-certificates", value = "true")
+class CleanupSpecInjectedHttpClientHttpsRequestSpec extends Specification {
+
+    @Shared
+    private static final EmbeddedServer EXTERNAL_SERVER = ApplicationContext.run(
+        EmbeddedServer,
+        [
+            "micronaut.server.port": -1,
+            "micronaut.server.ssl.enabled": true,
+            "micronaut.server.ssl.build-self-signed": true
+        ]
+    )
+
+    @Inject
+    @Shared
+    HttpClient client
+
+    void cleanupSpec() {
+        try {
+            assert client.toBlocking().retrieve(HttpRequest.GET("${EXTERNAL_SERVER.getURL()}/test"), String) == "orignal"
+        } finally {
+            EXTERNAL_SERVER.stop()
+        }
+    }
+
+    void "shared injected client remains usable during cleanupSpec"() {
+        expect:
+        client.toBlocking().retrieve(HttpRequest.GET("${EXTERNAL_SERVER.getURL()}/test"), String) == "orignal"
+    }
+}


### PR DESCRIPTION
## Summary
- run the Spock cleanupSpec interceptor before Micronaut tears down the test class context
- preserve the existing afterTestClass, afterClass, and mock cleanup sequence in nested finally blocks
- add HTTPS regression coverage for both @Client("/") and injected shared HttpClient usage in cleanupSpec

Resolves #1191
