### PR TITLE
Delay Spock shutdown until cleanupSpec completes

### DIFF
--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -115,11 +115,23 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
         );
 
         spec.addCleanupSpecInterceptor(invocation -> {
-            afterTestClass(buildContext(invocation, null));
-            afterClass(invocation);
-
-            invocation.proceed();
-            singletonMocks.clear();
+            Throwable failure = null;
+            try {
+                invocation.proceed();
+            } catch (Throwable e) {
+                failure = e;
+                throw e;
+            } finally {
+                try {
+                    afterTestClass(buildContext(invocation, failure));
+                } finally {
+                    try {
+                        afterClass(invocation);
+                    } finally {
+                        singletonMocks.clear();
+                    }
+                }
+            }
         });
 
         spec.addSetupInterceptor(invocation -> {

--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -115,22 +115,33 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
         );
 
         spec.addCleanupSpecInterceptor(invocation -> {
-            Throwable failure = null;
+            Throwable primary = null;
             try {
                 invocation.proceed();
             } catch (Throwable e) {
-                failure = e;
-                throw e;
-            } finally {
-                try {
-                    afterTestClass(buildContext(invocation, failure));
-                } finally {
-                    try {
-                        afterClass(invocation);
-                    } finally {
-                        singletonMocks.clear();
-                    }
+                primary = e;
+            }
+            try {
+                afterTestClass(buildContext(invocation, primary));
+            } catch (Throwable e) {
+                if (primary == null) {
+                    primary = e;
+                } else {
+                    primary.addSuppressed(e);
                 }
+            }
+            try {
+                afterClass(invocation);
+            } catch (Throwable e) {
+                if (primary == null) {
+                    primary = e;
+                } else {
+                    primary.addSuppressed(e);
+                }
+            }
+            singletonMocks.clear();
+            if (primary != null) {
+                throw primary;
             }
         });
 

--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Callable;
 
 /**
  * Extension for Spock.
@@ -115,39 +116,20 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
         );
 
         spec.addCleanupSpecInterceptor(invocation -> {
-            Throwable primary = null;
-            try {
-                invocation.proceed();
-            } catch (Throwable e) {
-                primary = e;
-            }
-            try {
-                afterTestClass(buildContext(invocation, primary));
-            } catch (Throwable e) {
-                if (primary == null) {
-                    primary = e;
-                } else {
-                    primary.addSuppressed(e);
-                }
-            }
-            try {
+            Throwable primary = captureCleanupSpecFailure(invocation);
+            TestContext testContext = buildContext(invocation, primary);
+            primary = collectCleanupFailure(primary, () -> {
+                afterTestClass(testContext);
+                return null;
+            });
+            primary = collectCleanupFailure(primary, () -> {
                 afterClass(invocation);
-            } catch (Throwable e) {
-                if (primary == null) {
-                    primary = e;
-                } else {
-                    primary.addSuppressed(e);
-                }
-            }
-            try {
+                return null;
+            });
+            primary = collectCleanupFailure(primary, () -> {
                 singletonMocks.clear();
-            } catch (Throwable e) {
-                if (primary == null) {
-                    primary = e;
-                } else {
-                    primary.addSuppressed(e);
-                }
-            }
+                return null;
+            });
             if (primary != null) {
                 throw primary;
             }
@@ -254,6 +236,36 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
         } else {
             return null;
         }
+    }
+
+    private Throwable captureCleanupSpecFailure(IMethodInvocation invocation) throws Throwable {
+        try {
+            invocation.proceed();
+            return null;
+        } catch (Exception e) {
+            return e;
+        } catch (Error e) {
+            return e;
+        }
+    }
+
+    private Throwable collectCleanupFailure(Throwable primary, Callable<Void> cleanupStep) {
+        try {
+            cleanupStep.call();
+        } catch (Exception e) {
+            return addCleanupFailure(primary, e);
+        } catch (Error e) {
+            return addCleanupFailure(primary, e);
+        }
+        return primary;
+    }
+
+    private Throwable addCleanupFailure(Throwable primary, Throwable cleanupFailure) {
+        if (primary == null) {
+            return cleanupFailure;
+        }
+        primary.addSuppressed(cleanupFailure);
+        return primary;
     }
 
     private TestContext buildContext(IMethodInvocation invocation, Throwable exception) {

--- a/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
+++ b/test-spock/src/main/java/io/micronaut/test/extensions/spock/MicronautSpockExtension.java
@@ -139,7 +139,15 @@ public class MicronautSpockExtension<T extends Annotation> extends AbstractMicro
                     primary.addSuppressed(e);
                 }
             }
-            singletonMocks.clear();
+            try {
+                singletonMocks.clear();
+            } catch (Throwable e) {
+                if (primary == null) {
+                    primary = e;
+                } else {
+                    primary.addSuppressed(e);
+                }
+            }
             if (primary != null) {
                 throw primary;
             }

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecRunningApplicationSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/CleanupSpecRunningApplicationSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Shared
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@MicronautTest(transactional = false)
+class CleanupSpecRunningApplicationSpec extends Specification {
+
+    @Shared
+    @Inject
+    ApplicationContext applicationContext
+
+    void cleanupSpec() {
+        assert applicationContext != null
+        assert applicationContext.isRunning()
+    }
+
+    void "application remains running until cleanupSpec completes"() {
+        expect:
+        applicationContext.isRunning()
+    }
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/FixtureWithAnnotationSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/FixtureWithAnnotationSpec.groovy
@@ -7,6 +7,10 @@ import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.SpecInfo
 import spock.lang.Specification
 
+import java.lang.reflect.Field
+import java.util.ArrayDeque
+import java.util.Queue
+
 @MicronautTest
 class FixtureWithAnnotationSpec extends Specification {
     static Boolean firstTestPassed = false
@@ -72,5 +76,94 @@ class FixtureWithAnnotationSpec extends Specification {
 
         then:
         1 * invocation.proceed()
+    }
+
+    def "CleanupSpec should retain the cleanupSpec failure and suppress teardown failures"() {
+        given:
+        SpecInfo specInfo = new SpecInfo()
+        IMethodInvocation invocation = Mock()
+        RuntimeException cleanupFailure = new RuntimeException("cleanupSpec failed")
+        Exception afterTestClassFailure = new Exception("afterTestClass failed")
+        RuntimeException afterClassFailure = new RuntimeException("afterClass failed")
+        RuntimeException singletonMocksFailure = new RuntimeException("singletonMocks.clear failed")
+        TestMicronautSpockExtension micronautSpockExtension = new TestMicronautSpockExtension(
+                afterTestClassFailure: afterTestClassFailure,
+                afterClassFailure: afterClassFailure
+        )
+        setSingletonMocks(micronautSpockExtension, new ThrowingQueue(failure: singletonMocksFailure))
+
+        when:
+        micronautSpockExtension.visitSpecAnnotation((MicronautTest) null, specInfo)
+        specInfo.cleanupSpecInterceptors[0].intercept(invocation)
+
+        then:
+        RuntimeException e = thrown()
+        e.is(cleanupFailure)
+        e.suppressed as List == [afterTestClassFailure, afterClassFailure, singletonMocksFailure]
+        1 * invocation.proceed() >> { throw cleanupFailure }
+    }
+
+    def "CleanupSpec should throw the first teardown failure when cleanupSpec succeeds"() {
+        given:
+        SpecInfo specInfo = new SpecInfo()
+        IMethodInvocation invocation = Mock()
+        Exception afterTestClassFailure = new Exception("afterTestClass failed")
+        RuntimeException afterClassFailure = new RuntimeException("afterClass failed")
+        RuntimeException singletonMocksFailure = new RuntimeException("singletonMocks.clear failed")
+        TestMicronautSpockExtension micronautSpockExtension = new TestMicronautSpockExtension(
+                afterTestClassFailure: afterTestClassFailure,
+                afterClassFailure: afterClassFailure
+        )
+        setSingletonMocks(micronautSpockExtension, new ThrowingQueue(failure: singletonMocksFailure))
+
+        when:
+        micronautSpockExtension.visitSpecAnnotation((MicronautTest) null, specInfo)
+        specInfo.cleanupSpecInterceptors[0].intercept(invocation)
+
+        then:
+        Exception e = thrown()
+        e.is(afterTestClassFailure)
+        e.suppressed as List == [afterClassFailure, singletonMocksFailure]
+        1 * invocation.proceed()
+    }
+
+    private static void setSingletonMocks(MicronautSpockExtension extension, Queue<Object> singletonMocks) {
+        Field field = MicronautSpockExtension.getDeclaredField("singletonMocks")
+        field.accessible = true
+        field.set(extension, singletonMocks)
+    }
+
+    static class TestMicronautSpockExtension extends MicronautSpockExtension {
+        Throwable afterTestClassFailure
+        Throwable afterClassFailure
+
+        @Override
+        void afterTestClass(io.micronaut.test.context.TestContext testContext) throws Exception {
+            throwFailure(afterTestClassFailure)
+        }
+
+        @Override
+        protected void afterClass(IMethodInvocation context) {
+            throwFailure(afterClassFailure)
+        }
+
+        private static void throwFailure(Throwable failure) throws Exception {
+            if (failure == null) {
+                return
+            }
+            if (failure instanceof Exception) {
+                throw (Exception) failure
+            }
+            throw (Error) failure
+        }
+    }
+
+    static class ThrowingQueue extends ArrayDeque<Object> {
+        RuntimeException failure
+
+        @Override
+        void clear() {
+            throw failure
+        }
     }
 }


### PR DESCRIPTION
## Summary
- delay Micronaut shutdown until after Spock cleanupSpec executes
- preserve after-class teardown in a finally block even when cleanupSpec fails
- add a regression spec covering access to the running application context in cleanupSpec

## Verification
- ./gradlew :micronaut-test-spock:test --tests 'io.micronaut.test.spock.CleanupSpecRunningApplicationSpec' --tests 'io.micronaut.test.spock.ShutdownEventSpec'\n- ./gradlew :micronaut-test-spock:test --tests 'io.micronaut.test.spock.FixtureWithAnnotationSpec'\n\nResolves #1179