### PR TITLE
Fix JUnit ApplicationContext parameter injection

### DIFF
--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -366,6 +366,10 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
                 return false;
             }
 
+            if (isApplicationContextParameter(parameterContext)) {
+                return true;
+            }
+
             final Argument<?> argument = getArgument(parameterContext, applicationContext);
             if (argument != null) {
                 if (argument.isAnnotationPresent(Value.class) || argument.isAnnotationPresent(Property.class)) {
@@ -383,6 +387,10 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        if (isApplicationContextParameter(parameterContext)) {
+            return applicationContext;
+        }
+
         final Argument<?> argument = getArgument(parameterContext, applicationContext);
         if (argument != null) {
             Optional<String> v = argument.getAnnotationMetadata().stringValue(Value.class);
@@ -441,6 +449,10 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         extensionContext.getTestInstances().ifPresent(testInstances -> {
             testInstances.getEnclosingInstances().forEach(applicationContext::inject);
         });
+    }
+
+    private boolean isApplicationContextParameter(ParameterContext parameterContext) {
+        return parameterContext.getParameter().getType().isInstance(applicationContext);
     }
 
     private Argument<?> getArgument(ParameterContext parameterContext, ApplicationContext applicationContext) {

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -452,7 +452,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
     }
 
     private boolean isApplicationContextParameter(ParameterContext parameterContext) {
-        return parameterContext.getParameter().getType().isInstance(applicationContext);
+        return ApplicationContext.class.isAssignableFrom(parameterContext.getParameter().getType());
     }
 
     private Argument<?> getArgument(ParameterContext parameterContext, ApplicationContext applicationContext) {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationContextArgumentInjectionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ApplicationContextArgumentInjectionTest.java
@@ -1,0 +1,18 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@MicronautTest
+class ApplicationContextArgumentInjectionTest {
+
+    @Test
+    void injectsApplicationContextIntoTestMethod(ApplicationContext applicationContext) {
+        assertNotNull(applicationContext);
+        assertSame(applicationContext, applicationContext.getBean(ApplicationContext.class));
+    }
+}


### PR DESCRIPTION
## Summary
- allow JUnit 5 test method parameters to resolve the running ApplicationContext directly
- add a regression test covering ApplicationContext argument injection

Resolves #1108