### PR TITLE
Add regression tests for startApplication lifecycle events

### DIFF
--- a/test-junit5/src/test/java/io/micronaut/test/junit5/DisableEmbeddedApplicationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/DisableEmbeddedApplicationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import jakarta.inject.Inject;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @MicronautTest(startApplication = false, rebuildContext = true)
@@ -19,15 +20,20 @@ class DisableEmbeddedApplicationTest {
     @Inject
     private EmbeddedApplication<?> embeddedApplication;
 
+    @Inject
+    private ServerStartupEventListener serverStartupEventListener;
+
     @Test
     @Order(1)
     void embeddedApplicationIsNotStartedWhenContextIsStarted() {
         assertFalse(embeddedApplication.isRunning());
+        assertEquals(0, serverStartupEventListener.getInvocationCount());
     }
 
     @Test
     @Order(2)
     void embeddedApplicationIsNotStartedWhenContextIsRebuilt() {
         assertFalse(embeddedApplication.isRunning());
+        assertEquals(0, serverStartupEventListener.getInvocationCount());
     }
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/ServerStartupEventListener.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/ServerStartupEventListener.java
@@ -1,0 +1,21 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Singleton
+class ServerStartupEventListener {
+    private final AtomicInteger invocationCount = new AtomicInteger();
+
+    @EventListener
+    void onStartup(ServerStartupEvent event) {
+        invocationCount.incrementAndGet();
+    }
+
+    int getInvocationCount() {
+        return invocationCount.get();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/StartEmbeddedApplicationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/StartEmbeddedApplicationTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+class StartEmbeddedApplicationTest {
+
+    @Inject
+    private EmbeddedApplication<?> embeddedApplication;
+
+    @Inject
+    private ServerStartupEventListener serverStartupEventListener;
+
+    @Test
+    void embeddedApplicationPublishesServerStartupEvent() {
+        assertTrue(embeddedApplication.isRunning());
+        assertEquals(1, serverStartupEventListener.getInvocationCount());
+    }
+}


### PR DESCRIPTION
## Summary
- add a listener-backed regression test proving normal embedded application startup emits `ServerStartupEvent`
- verify `@MicronautTest(startApplication = false)` does not start the embedded application or publish startup events when the context is created or rebuilt

Resolves #796