### PR TITLE
Fix MockBean with rebuildContext=true and nested tests

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -446,6 +446,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
 
         if (testInstance != null) {
             if (applicationContext != null) {
+                beforeInjectTestInstance(context, testInstance);
                 if (refreshScope != null) {
                     refreshScope.onRefreshEvent(new RefreshEvent(Collections.singletonMap(
                         TestActiveCondition.ACTIVE_MOCKS, "changed"
@@ -521,6 +522,16 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
      * @param instance The mock instance to inject
      */
     protected abstract void alignMocks(C context, Object instance);
+
+    /**
+     * Allows implementations to inject enclosing or related test instances before the current
+     * test instance is injected and mock fields are aligned.
+     *
+     * @param context The context
+     * @param testInstance The current test instance
+     */
+    protected void beforeInjectTestInstance(C context, Object testInstance) {
+    }
 
     private void startEmbeddedApplication() {
         if (embeddedApplication != null) {

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -225,7 +225,6 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
-        injectEnclosingTestInstances(extensionContext);
         final Optional<Object> testInstance = extensionContext.getTestInstance();
         final Optional<? extends AnnotatedElement> testMethod = extensionContext.getTestMethod();
         List<Property> propertyAnnotations = null;
@@ -294,6 +293,11 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
                 testProperties.putAll(properties);
             }
         }
+    }
+
+    @Override
+    protected void beforeInjectTestInstance(ExtensionContext extensionContext, Object testInstance) {
+        injectEnclosingTestInstances(extensionContext);
     }
 
     @Override

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedRebuildContextTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedRebuildContextTest.java
@@ -1,0 +1,48 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+@MicronautTest(rebuildContext = true)
+@Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
+class MockBeanNestedRebuildContextTest {
+
+    @Inject
+    SomeBean someBean;
+
+    @Nested
+    class FirstNestedClass {
+
+        @Test
+        void mockIsAvailable() {
+            assertNotNull(someBean);
+        }
+    }
+
+    @Nested
+    class SecondNestedClass {
+
+        @Test
+        void mockIsStillAvailable() {
+            assertNotNull(someBean);
+        }
+    }
+
+    @MockBean(SomeBean.class)
+    SomeBean someBean() {
+        return mock(SomeBean.class);
+    }
+
+    @Singleton
+    static class SomeBean {
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedRebuildContextTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MockBeanNestedRebuildContextTest.java
@@ -10,7 +10,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 
 @MicronautTest(rebuildContext = true)
 @Requires(property = "mockito.test.enabled", defaultValue = StringUtils.FALSE, value = StringUtils.TRUE)
@@ -19,12 +22,16 @@ class MockBeanNestedRebuildContextTest {
     @Inject
     SomeBean someBean;
 
+    static SomeBean firstMock;
+
     @Nested
     class FirstNestedClass {
 
         @Test
         void mockIsAvailable() {
             assertNotNull(someBean);
+            assertTrue(mockingDetails(someBean).isMock(), "someBean should be a Mockito mock");
+            firstMock = someBean;
         }
     }
 
@@ -34,11 +41,13 @@ class MockBeanNestedRebuildContextTest {
         @Test
         void mockIsStillAvailable() {
             assertNotNull(someBean);
+            assertTrue(mockingDetails(someBean).isMock(), "someBean should be a Mockito mock");
+            assertNotSame(firstMock, someBean, "someBean should be a fresh mock after context rebuild, not a stale proxy");
         }
     }
 
     @MockBean(SomeBean.class)
-    SomeBean someBean() {
+    SomeBean mockSomeBean() {
         return mock(SomeBean.class);
     }
 


### PR DESCRIPTION
When `@MicronautTest(rebuildContext = true)` is used with JUnit 5 nested test classes and `@MockBean`, the enclosing test instance can keep mock proxies from the previous stopped context. That breaks mock alignment on the next nested test run with `Cannot resolve beans until the context is running`.

This changes the JUnit 5 extension to re-inject enclosing test instances through the shared reinjection path that runs after a context rebuild, so stale proxies are replaced before mock alignment unwraps them. It also adds a focused regression test covering nested classes with `rebuildContext = true`.

Supersedes #1370.

Resolves #1203