### PR TITLE
Fix native JUnit test activation on Windows

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -76,6 +76,7 @@ import java.util.Optional;
  * @since 1.0
  */
 public abstract class AbstractMicronautExtension<C> implements TestExecutionListener, TestMethodInterceptor<Object> {
+    public static final String NATIVE_IMAGE_CODE_PROPERTY = "org.graalvm.nativeimage.imagecode";
     public static final String TEST_ROLLBACK = "micronaut.test.rollback";
     public static final String TEST_TRANSACTIONAL = "micronaut.test.transactional";
     public static final String TEST_TRANSACTION_MODE = "micronaut.test.transaction-mode";
@@ -510,10 +511,17 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
      * @return true if the te given class has a bean definition class in the classpath (ie: the annotation processor has been run correctly)
      */
     protected boolean isTestSuiteBeanPresent(Class<?> requiredTestClass) {
+        if (isNativeImageExecution()) {
+            return true;
+        }
         String prefix = requiredTestClass.getPackage().getName() + ".$" + requiredTestClass.getSimpleName();
         final ClassLoader classLoader = requiredTestClass.getClassLoader();
         return ClassUtils.isPresent(prefix + "Definition", classLoader) ||
                ClassUtils.isPresent(prefix + "$Definition", classLoader);
+    }
+
+    protected boolean isNativeImageExecution() {
+        return StringUtils.isNotEmpty(System.getProperty(NATIVE_IMAGE_CODE_PROPERTY));
     }
 
     /**

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -249,7 +249,7 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
         if (testInstance.isPresent()) {
 
             final Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-            if (applicationContext.containsBean(requiredTestClass) || isNestedTestClass(requiredTestClass)) {
+            if (applicationContext.containsBean(requiredTestClass) || specDefinition != null || isNestedTestClass(requiredTestClass)) {
                 return ConditionEvaluationResult.enabled("Test bean active");
             } else {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/MicronautJunit5ExtensionTest.java
@@ -1,0 +1,91 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MicronautJunit5ExtensionTest {
+    private static final String NATIVE_IMAGE_CODE_PROPERTY = "org.graalvm.nativeimage.imagecode";
+
+    @Test
+    void testConditionUsesResolvedSpecDefinitionWhenBeanLookupFails() {
+        TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        ExtensionContext extensionContext = mock(ExtensionContext.class);
+        BeanDefinition<?> beanDefinition = mock(BeanDefinition.class);
+
+        extension.setApplicationContext(applicationContext);
+        extension.setSpecDefinition(beanDefinition);
+
+        when(extensionContext.getTestInstance()).thenReturn(Optional.of(new AnnotatedTest()));
+        doReturn(AnnotatedTest.class).when(extensionContext).getRequiredTestClass();
+        when(applicationContext.containsBean(AnnotatedTest.class)).thenReturn(false);
+
+        ConditionEvaluationResult result = evaluateInNativeImage(() -> extension.evaluateExecutionCondition(extensionContext));
+
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void testConditionStillDisablesWhenNoActiveBeanOrDefinitionExists() {
+        TestMicronautJunit5Extension extension = new TestMicronautJunit5Extension();
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        ExtensionContext extensionContext = mock(ExtensionContext.class);
+
+        extension.setApplicationContext(applicationContext);
+        extension.setSpecDefinition(null);
+
+        when(extensionContext.getTestInstance()).thenReturn(Optional.of(new AnnotatedTest()));
+        doReturn(AnnotatedTest.class).when(extensionContext).getRequiredTestClass();
+        when(applicationContext.containsBean(AnnotatedTest.class)).thenReturn(false);
+
+        ConditionEvaluationResult result = evaluateInNativeImage(() -> extension.evaluateExecutionCondition(extensionContext));
+
+        assertTrue(result.isDisabled());
+    }
+
+    private static ConditionEvaluationResult evaluateInNativeImage(ResultSupplier<ConditionEvaluationResult> supplier) {
+        String previous = System.getProperty(NATIVE_IMAGE_CODE_PROPERTY);
+        System.setProperty(NATIVE_IMAGE_CODE_PROPERTY, "runtime");
+        try {
+            return supplier.get();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(NATIVE_IMAGE_CODE_PROPERTY);
+            } else {
+                System.setProperty(NATIVE_IMAGE_CODE_PROPERTY, previous);
+            }
+        }
+    }
+
+    @MicronautTest
+    static final class AnnotatedTest {
+    }
+
+    static final class TestMicronautJunit5Extension extends MicronautJunit5Extension {
+        void setApplicationContext(ApplicationContext applicationContext) {
+            this.applicationContext = applicationContext;
+        }
+
+        void setSpecDefinition(BeanDefinition<?> specDefinition) {
+            this.specDefinition = specDefinition;
+        }
+    }
+
+    @FunctionalInterface
+    interface ResultSupplier<T> {
+        T get();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/NativeImageBeanPresenceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/NativeImageBeanPresenceTest.java
@@ -1,0 +1,57 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.test.annotation.MicronautTestValue;
+import io.micronaut.test.extensions.AbstractMicronautExtension;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NativeImageBeanPresenceTest {
+    private static final String NATIVE_IMAGE_CODE_PROPERTY = "org.graalvm.nativeimage.imagecode";
+
+    private final TestExtension extension = new TestExtension();
+
+    @Test
+    void testBeanPresenceStillRequiresGeneratedDefinitionOnJvm() {
+        assertFalse(extension.hasBeanDefinition(PlainClass.class));
+    }
+
+    @Test
+    void testBeanPresenceIsBypassedInNativeImage() {
+        String previous = System.getProperty(NATIVE_IMAGE_CODE_PROPERTY);
+        System.setProperty(NATIVE_IMAGE_CODE_PROPERTY, "runtime");
+        try {
+            assertTrue(extension.hasBeanDefinition(PlainClass.class));
+        } finally {
+            restoreNativeImageProperty(previous);
+        }
+    }
+
+    private static void restoreNativeImageProperty(String previous) {
+        if (previous == null) {
+            System.clearProperty(NATIVE_IMAGE_CODE_PROPERTY);
+        } else {
+            System.setProperty(NATIVE_IMAGE_CODE_PROPERTY, previous);
+        }
+    }
+
+    static final class PlainClass {
+    }
+
+    static final class TestExtension extends AbstractMicronautExtension<Object> {
+        boolean hasBeanDefinition(Class<?> testClass) {
+            return isTestSuiteBeanPresent(testClass);
+        }
+
+        @Override
+        protected void resolveTestProperties(Object context, MicronautTestValue testAnnotationValue, Map<String, Object> testProperties) {
+        }
+
+        @Override
+        protected void alignMocks(Object context, Object instance) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bypass test bean-definition presence checks when running inside a native image
- treat a resolved JUnit spec definition as an active test bean during condition evaluation
- add regressions covering native-image bean detection and execution-condition handling

## Verification
- ./gradlew :micronaut-test-junit5:test --tests "io.micronaut.test.junit5.MicronautJunit5ExtensionTest" --tests "io.micronaut.test.junit5.NativeImageBeanPresenceTest"
- ./gradlew :micronaut-test-junit5:test

Resolves #779