### PR TITLE
Allow to disable default transactional behaviour

### DIFF
--- a/src/main/docs/guide/includes/transaction.adoc
+++ b/src/main/docs/guide/includes/transaction.adoc
@@ -1,5 +1,7 @@
 When using `@MicronautTest` each `@Test` method will be wrapped in a transaction that will be rolled back when the test finishes. This behaviour can be changed by using the `transactional` and `rollback` properties.
 
+The default transactional behaviour can also be controlled through configuration. Set the `micronaut.test.transactional` property (for example in `application-test.properties` or as a system property) to `false` to disable transactions for all tests that do not explicitly specify the `transactional` member. Alternatively, set `micronaut.test.transactional-default=false` to require tests to opt in with `@MicronautTest(transactional = true)` while still allowing per-test overrides.
+
 To avoid creating a transaction:
 
 ```java

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -27,6 +27,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.context.env.PropertySourcesLocator;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.scan.ClassClassPathResourceLoader;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
@@ -81,6 +82,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     public static final String TEST_ROLLBACK = "micronaut.test.rollback";
     public static final String TEST_TRANSACTIONAL = "micronaut.test.transactional";
     public static final String TEST_TRANSACTION_MODE = "micronaut.test.transaction-mode";
+    public static final String TEST_TRANSACTIONAL_DEFAULT = "micronaut.test.transactional-default";
     public static final String DISABLED_MESSAGE = "Test is not bean. Either the test does not satisfy requirements defined by @Requires or annotation processing is not enabled. If the latter ensure annotation processing is enabled in your IDE.";
     public static final String MISCONFIGURED_MESSAGE = """
         @MicronautTest used on test but no bean definition for the test present. \
@@ -249,7 +251,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     /**
      * Actually fires the execution listener.
      *
-     * @param callback the execution listener callback
+     * @param callback    the execution listener callback
      * @param testContext the test context
      * @throws Exception allows any exception to propagate
      */
@@ -285,8 +287,10 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
 
             final Package aPackage = testClass.getPackage();
             builder.packages(aPackage.getName());
+            ClassPathResourceLoader classPathResourceLoader = ClassPathResourceLoader.defaultLoader(null);
+            ClassLoader classLoader = classPathResourceLoader.getClassLoader();
             builder.resourceResolver(CombinedClassPathResourceLoader.of(
-                ClassPathResourceLoader.defaultLoader(null),
+                classPathResourceLoader,
                 new ClassClassPathResourceLoader(testClass)
             ));
             final List<Property> ps = AnnotationUtils.findRepeatableAnnotations(testClass, Property.class);
@@ -297,7 +301,6 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
 
             testProperties.put(TestActiveCondition.ACTIVE_SPEC_CLAZZ, testClass);
             testProperties.put(TEST_ROLLBACK, String.valueOf(testAnnotationValue.rollback()));
-            testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
             testProperties.put(TEST_TRANSACTION_MODE, String.valueOf(testAnnotationValue.transactionMode()));
             testProperties.put(Environment.DEDUCE_ENVIRONMENT_PROPERTY, String.valueOf(testAnnotationValue.deduceEnvironment()));
             final Class<?> application = testAnnotationValue.application();
@@ -365,6 +368,16 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                             testProperties.putAll(provider.get());
                         }
                     }
+                    Object testTransactionalDefault = testProperties.get(TEST_TRANSACTIONAL_DEFAULT);
+                    if (testTransactionalDefault != null && !Boolean.parseBoolean(testTransactionalDefault.toString())) {
+                        if (isExplicitTransactionalValue(classLoader)) {
+                            testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
+                        } else {
+                            testProperties.put(TEST_TRANSACTIONAL, Boolean.FALSE.toString());
+                        }
+                    } else if (!testProperties.containsKey(TEST_TRANSACTIONAL)) {
+                        testProperties.put(TEST_TRANSACTIONAL, String.valueOf(testAnnotationValue.transactional()));
+                    }
                     if (!testProperties.isEmpty()) {
                         loadedPropertySources.add(PropertySource.of(TEST_PROPERTY_SOURCE, testProperties));
                     }
@@ -392,6 +405,16 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         }
     }
 
+    private boolean isExplicitTransactionalValue(ClassLoader classLoader) {
+        try {
+            Class<?> beanDefinitionClass = classLoader.loadClass(testClass.getPackage().getName() + ".$" + testClass.getSimpleName() + "$Definition");
+            BeanDefinition<?> beanDefinition = (BeanDefinition<?>) beanDefinitionClass.getDeclaredConstructor().newInstance();
+            return isMicronautTestTransactionalDeclared(beanDefinition);
+        } catch (Exception ignore) {
+            return false;
+        }
+    }
+
     /**
      * Allows subclasses to customize the builder right before context initialization.
      *
@@ -403,18 +426,18 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     /**
      * Resolves any test properties.
      *
-     * @param context The test context
+     * @param context             The test context
      * @param testAnnotationValue The test annotation
-     * @param testProperties The test properties
+     * @param testProperties      The test properties
      */
     protected abstract void resolveTestProperties(C context, MicronautTestValue testAnnotationValue, Map<String, Object> testProperties);
 
     /**
      * To be called by the different implementations before each test method.
      *
-     * @param context The test context
-     * @param testInstance The test instance
-     * @param method The test method
+     * @param context             The test context
+     * @param testInstance        The test instance
+     * @param method              The test method
      * @param propertyAnnotations The {@code @Property} annotations found in the test method, if any
      */
     protected void beforeEach(C context, @Nullable Object testInstance, @Nullable AnnotatedElement method, List<Property> propertyAnnotations) {
@@ -509,6 +532,19 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         oldValues.clear();
     }
 
+    private static boolean isMicronautTestTransactionalDeclared(AnnotationMetadata metadata) {
+        for (String annotationName : metadata.getAnnotationNames()) {
+            if (!annotationName.endsWith(".MicronautTest")) {
+                continue;
+            }
+            Map<CharSequence, Object> declaredValues = metadata.getValues(annotationName);
+            if (declaredValues.containsKey("transactional")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Starts the application context.
      */
@@ -527,11 +563,11 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
         String prefix = requiredTestClass.getPackage().getName() + ".$" + requiredTestClass.getSimpleName();
         final ClassLoader classLoader = requiredTestClass.getClassLoader();
         return ClassUtils.isPresent(prefix + "Definition", classLoader) ||
-               ClassUtils.isPresent(prefix + "$Definition", classLoader);
+            ClassUtils.isPresent(prefix + "$Definition", classLoader);
     }
 
     /**
-     * @param context The context
+     * @param context  The context
      * @param instance The mock instance to inject
      */
     protected abstract void alignMocks(C context, Object instance);

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyExplicitTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyExplicitTest.java
@@ -1,0 +1,35 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.transaction.test.DefaultTestTransactionExecutionListener;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Collections;
+import java.util.Map;
+
+@MicronautTest(transactional = true)
+@DbProperties
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TransactionalDefaultPropertyExplicitTest implements TestPropertyProvider {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap("micronaut.test.transactional-default", "false");
+    }
+
+    @Test
+    void transactionalEnabledWhenExplicit() {
+        Assertions.assertTrue(applicationContext.containsBean(DefaultTestTransactionExecutionListener.class));
+        Assertions.assertTrue(applicationContext.getEnvironment()
+            .getProperty("micronaut.test.transactional", Boolean.class)
+            .orElse(false));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyTest.java
@@ -1,0 +1,32 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.transaction.test.DefaultTestTransactionExecutionListener;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Collections;
+import java.util.Map;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TransactionalDefaultPropertyTest implements TestPropertyProvider {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap("micronaut.test.transactional-default", "false");
+    }
+
+    @Test
+    void transactionalDisabledByDefaultProperty() {
+        Assertions.assertFalse(applicationContext.containsBean(DefaultTestTransactionExecutionListener.class));
+        Assertions.assertFalse(applicationContext.getEnvironment().getProperty("micronaut.test.transactional", Boolean.class).orElse(true));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalPropertyOverrideTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalPropertyOverrideTest.java
@@ -1,0 +1,32 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import io.micronaut.transaction.test.DefaultTestTransactionExecutionListener;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Collections;
+import java.util.Map;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TransactionalPropertyOverrideTest implements TestPropertyProvider {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap("micronaut.test.transactional", "false");
+    }
+
+    @Test
+    void transactionalDisabledByProperty() {
+        Assertions.assertFalse(applicationContext.containsBean(DefaultTestTransactionExecutionListener.class));
+        Assertions.assertFalse(applicationContext.getEnvironment().getProperty("micronaut.test.transactional", Boolean.class).orElse(true));
+    }
+}

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TransactionalDefaultPropertyExplicitTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TransactionalDefaultPropertyExplicitTest.kt
@@ -1,0 +1,22 @@
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+@MicronautTest(transactional = true)
+@Property(name = "micronaut.test.transactional-default", value = "false")
+class TransactionalDefaultPropertyExplicitTest(
+    private val applicationContext: ApplicationContext
+) : StringSpec() {
+
+    init {
+        "explicit transactional annotation wins over default property" {
+            applicationContext.environment
+                .getProperty("micronaut.test.transactional", Boolean::class.java)
+                .orElse(false) shouldBe true
+        }
+    }
+}

--- a/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TransactionalDefaultPropertyTest.kt
+++ b/test-kotest5/src/test/kotlin/io/micronaut/test/kotest5/TransactionalDefaultPropertyTest.kt
@@ -1,0 +1,22 @@
+package io.micronaut.test.kotest5
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+@MicronautTest
+@Property(name = "micronaut.test.transactional-default", value = "false")
+class TransactionalDefaultPropertyTest(
+    private val applicationContext: ApplicationContext
+) : StringSpec() {
+
+    init {
+        "transactions disabled when default property false" {
+            applicationContext.environment
+                .getProperty("micronaut.test.transactional", Boolean::class.java)
+                .orElse(true) shouldBe false
+        }
+    }
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/TransactionalDefaultPropertyExplicitSpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/TransactionalDefaultPropertyExplicitSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(transactional = true)
+class TransactionalDefaultPropertyExplicitSpec extends Specification implements TestPropertyProvider {
+
+    @Inject
+    ApplicationContext applicationContext
+
+    @Override
+    Map<String, String> getProperties() {
+        ['micronaut.test.transactional-default': 'false']
+    }
+
+    void "explicit transactional annotation wins over default property"() {
+        expect:
+        applicationContext.environment.getProperty('micronaut.test.transactional', Boolean).orElse(false)
+    }
+}

--- a/test-spock/src/test/groovy/io/micronaut/test/spock/TransactionalDefaultPropertySpec.groovy
+++ b/test-spock/src/test/groovy/io/micronaut/test/spock/TransactionalDefaultPropertySpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.test.spock
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class TransactionalDefaultPropertySpec extends Specification implements TestPropertyProvider {
+
+    @Inject
+    ApplicationContext applicationContext
+
+    @Override
+    Map<String, String> getProperties() {
+        ['micronaut.test.transactional-default': 'false']
+    }
+
+    void "transactions disabled when default property false"() {
+        expect:
+        !applicationContext.environment.getProperty('micronaut.test.transactional', Boolean).orElse(true)
+    }
+}


### PR DESCRIPTION
One of the solutions for https://github.com/micronaut-projects/micronaut-test/issues/967

The next step would be to introduce something like `@TransactionalTest` and move all the tx stuff there + deprecate the old value