### PR TITLE
Fix @Sql splitting of PostgreSQL dollar-quoted blocks

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/support/sql/SqlScriptStatementSplitter.java
+++ b/test-core/src/main/java/io/micronaut/test/support/sql/SqlScriptStatementSplitter.java
@@ -180,6 +180,11 @@ final class SqlScriptStatementSplitter {
                 appendQuoted(currentStatement, current);
                 return false;
             }
+            if (current == '$') {
+                if (appendDollarQuoted(currentStatement)) {
+                    return false;
+                }
+            }
 
             index++;
             if (current == ';') {
@@ -203,6 +208,35 @@ final class SqlScriptStatementSplitter {
                     }
                 }
             }
+        }
+
+        private boolean appendDollarQuoted(StringBuilder currentStatement) {
+            int tagEnd = script.indexOf('$', index + 1);
+            if (tagEnd < 0 || !isDollarQuoteTag(index + 1, tagEnd)) {
+                return false;
+            }
+
+            String delimiter = script.substring(index, tagEnd + 1);
+            int closingDelimiterIndex = script.indexOf(delimiter, tagEnd + 1);
+            if (closingDelimiterIndex < 0) {
+                return false;
+            }
+
+            appendRange(currentStatement, closingDelimiterIndex + delimiter.length());
+            return true;
+        }
+
+        private boolean isDollarQuoteTag(int startInclusive, int endExclusive) {
+            for (int i = startInclusive; i < endExclusive; i++) {
+                char current = script.charAt(i);
+                if (i == startInclusive && Character.isDigit(current)) {
+                    return false;
+                }
+                if (current != '_' && !Character.isLetterOrDigit(current)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         private void appendRange(StringBuilder currentStatement, int endExclusive) {

--- a/test-core/src/test/java/io/micronaut/test/support/sql/SqlScriptStatementSplitterTest.java
+++ b/test-core/src/test/java/io/micronaut/test/support/sql/SqlScriptStatementSplitterTest.java
@@ -61,6 +61,36 @@ class SqlScriptStatementSplitterTest {
     }
 
     @Test
+    void keepsSemicolonsInsidePostgresDollarQuotedBlocks() {
+        String block = """
+            DO
+            $$
+                BEGIN
+                    INSERT INTO dummy_table(id, text, other_text)
+                    VALUES ('1836e92e-5f78-4ce4-9d52-bd00b8643827','my text','my other text');
+                END
+            $$;
+            """;
+
+        assertEquals(List.of(block.trim().replaceFirst(";$", "")), SqlScriptStatementSplitter.split(block));
+    }
+
+    @Test
+    void keepsSemicolonsInsidePostgresTaggedDollarQuotedBlocks() {
+        assertEquals(List.of(
+            "CREATE FUNCTION test_function() RETURNS void AS $body$\nBEGIN\n    DELETE FROM foo;\nEND;\n$body$ LANGUAGE plpgsql",
+            "DELETE FROM bar"
+        ), SqlScriptStatementSplitter.split("""
+            CREATE FUNCTION test_function() RETURNS void AS $body$
+            BEGIN
+                DELETE FROM foo;
+            END;
+            $body$ LANGUAGE plpgsql;
+            DELETE FROM bar;
+            """));
+    }
+
+    @Test
     void leavesPlSqlBlocksIntact() {
         String block = """
             BEGIN


### PR DESCRIPTION
Fixes #1465
This is likely regression from #1435

Summary:

  - Treat PostgreSQL dollar-quoted strings (`$$...$$` and tagged `$tag$...$tag$`) as quoted regions during `@Sql` script splitting.
  - Prevent semicolons inside PostgreSQL `DO` blocks and function bodies from being split into separate invalid SQL statements.
  - Add regression coverage for the reported `DO $$ ... $$` repro and tagged dollar-quoted function bodies.
  - Verified fix against reproducer