### PR TITLE
 Restore file: property source support in @MicronautTest

### DIFF
--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -29,6 +29,7 @@ import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.context.env.PropertySourcesLocator;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.io.scan.ClassClassPathResourceLoader;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.io.scan.CombinedClassPathResourceLoader;
@@ -326,6 +327,7 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                 @Override
                 public Collection<PropertySource> load(Environment environment) {
                     List<PropertySource> loadedPropertySources = new ArrayList<>();
+                    ResourceResolver resourceResolver = new ResourceResolver();
                     for (String propertySourceName : testAnnotationValue.propertySources()) {
                         String ext = NameUtils.extension(propertySourceName);
                         if (StringUtils.isEmpty(ext)) {
@@ -336,7 +338,9 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
                                 continue;
                             }
 
-                            environment.getResourceAsStream(propertySourceName).ifPresent(inputStream -> {
+                            resourceResolver.getResourceAsStream(propertySourceName)
+                                .or(() -> environment.getResourceAsStream(propertySourceName))
+                                .ifPresent(inputStream -> {
                                 try (inputStream) {
                                     String filename = NameUtils.filename(propertySourceName);
                                     try {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/PropertySourceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/PropertySourceTest.java
@@ -18,3 +18,15 @@ class PropertySourceTest {
         Assertions.assertEquals("foo", val);
     }
 }
+
+@MicronautTest(propertySources = "file:src/test/resources/io/micronaut/test/junit5/fileprops.properties")
+class FilePropertySourceTest {
+
+    @Property(name = "foo.file")
+    String val;
+
+    @Test
+    void testFilePropertySource() {
+        Assertions.assertEquals("file", val);
+    }
+}

--- a/test-junit5/src/test/resources/io/micronaut/test/junit5/fileprops.properties
+++ b/test-junit5/src/test/resources/io/micronaut/test/junit5/fileprops.properties
@@ -1,0 +1,1 @@
+foo.file=file


### PR DESCRIPTION
Closes : #1491 1491
 Restores support for filesystem-backed property source locations, such as:

`  @MicronautTest(propertySources = "file:application-external.properties")
`
  This behavior worked in Micronaut Test 4.x but regressed with the Core 5 migration.

  The regression came from replacing `ResourceResolver` with `Environment#getResourceAsStream`, which does not resolve the reporter’s `file: location`. The property source was silently skipped, allowing ```
` application-test.properties `to win instead.

  The fix resolves property sources with `ResourceResolver` first, then retains the environment resource lookup as a fallback for test-class classpath resources.

  ## Changes

-   Restore URI-backed property-source resolution in AbstractMicronautExtension.
-   Add a JUnit regression test for a file: properties location.

  ## Verification

  - ./gradlew --no-daemon :micronaut-test-junit5:test --tests io.micronaut.test.junit5.PropertySourceTest --tests io.micronaut.test.junit5.FilePropertySourceTest --rerun-tasks
  - ./gradlew --no-daemon spotlessCheck :micronaut-test-junit5:check
  - Published 5.1.1-SNAPSHOT to Maven Local and ran the original reproducer against:
      - micronaut-test-junit5:5.1.1-SNAPSHOT
      - micronaut-test-core:5.1.1-SNAPSHOT
      - Micronaut Core 5.1.6

  The previously failing external-file assertion now passes.
