### PR TITLE
Support JUnit 5 parallel test execution

### DIFF
--- a/src/main/docs/guide/junit5/junit5ParallelExecution.adoc
+++ b/src/main/docs/guide/junit5/junit5ParallelExecution.adoc
@@ -1,0 +1,72 @@
+JUnit 5 can run tests https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution[in parallel]. Micronaut Test supports this by guaranteeing that:
+
+* different `@MicronautTest` classes run **at the same time**, each with its own application context and, where applicable, its own embedded server;
+* everything that shares **one** application context runs **one at a time**.
+
+The second guarantee is what makes the first one safe. A `@MicronautTest` class owns a single `ApplicationContext` for the whole class, so its beans - including every api:test.annotation.MockBean[] - are singletons shared by every method of that class. Method level `@Property` values, `rebuildContext = true`, `@Sql` phases and api:test.context.TestExecutionListener[] state are all held per class as well. Running two methods of the same class concurrently would race on all of it.
+
+Micronaut Test enforces this with a https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization[JUnit resource lock] that `@MicronautTest` declares for you. There is nothing to configure: the lock is keyed on the test class, so it never serialises unrelated classes.
+
+NOTE: `@Nested` classes reuse the extension instance of their outermost enclosing class, so they lock on that class - a nested test never runs alongside the methods of the class that encloses it.
+
+=== Enabling parallel execution
+
+Parallel execution is a JUnit setting, not a Micronaut one. Enable it in `src/test/resources/junit-platform.properties`:
+
+[source,properties]
+----
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+----
+
+This is the recommended configuration: test classes run concurrently, methods within a class do not. Setting `mode.default=concurrent` as well is harmless - the resource lock keeps each context single-threaded regardless - but it buys you nothing unless you also opt classes in, as described below.
+
+=== Making your tests parallel-safe
+
+The lock protects the state Micronaut Test owns. It cannot protect anything your tests share *between* classes, and that is where most failures come from:
+
+* **In-memory databases.** Two classes pointing at `jdbc:h2:mem:testdb` share one database. Give each test class its own URL, or use https://micronaut-projects.github.io/micronaut-test-resources/latest/guide/[Test Resources].
+* **Fixed ports.** Let `@MicronautTest` allocate a random port rather than pinning `micronaut.server.port`.
+* **Static mutable state**, temporary files with fixed names, and system properties set from test code.
+* **Shared external services** - a single Testcontainers instance, a stub server, a message broker topic.
+
+TIP: Every additional concurrent class is another live application context, connection pool and embedded server. Raising `junit.jupiter.execution.parallel.config.fixed.parallelism` past what the machine can hold will slow the build down rather than speed it up.
+
+=== Running the methods of one class concurrently
+
+If a test class genuinely is thread-safe - no mocks, no method level `@Property`, no transactional fixtures, no shared bean state - declare `@Execution(CONCURRENT)` on the class to opt it out of the lock:
+
+[source,java]
+----
+@MicronautTest
+@Execution(ExecutionMode.CONCURRENT) // <1>
+class ReadOnlyEndpointTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/one", "/two", "/three"})
+    void endpointResponds(String path) {
+        // ...
+    }
+}
+----
+<1> Declared directly on the class. An execution mode that only comes from a configuration parameter is *not* treated as an opt-out, because it says nothing about whether this particular class was written to be thread-safe.
+
+From that point the thread safety of the test class, of the beans it injects and of any `TestExecutionListener` on its classpath is yours to guarantee. In particular, Micronaut Data's transaction support keeps one transaction per context, so a class using `@Transactional` fixtures must not opt out.
+
+To opt out for a whole JVM - for example to reproduce a race - set the `micronaut.test.parallel.methods` system property:
+
+[source,groovy]
+----
+test {
+    systemProperty "micronaut.test.parallel.methods", "true"
+}
+----
+
+=== Limitations
+
+* **JUnit 5.12 or newer is required.** The lock is declared with `@ResourceLock(providers = ...)`, and `providers` was added in JUnit 5.12. On an older JUnit the Jupiter engine fails to execute *any* `@MicronautTest` class. Micronaut Test manages a supported version for you; only override `junit-bom` upwards.
+* **The opt-out is per class, not per method.** A class either serialises all of its methods or none of them.
+* **A `@TestFactory` holds the lock for all of its dynamic tests**, because they execute inside the factory node.
+* **This applies to JUnit 5 only.** The Spock and Kotest integrations share the same extension state and do not carry the resource lock, so parallel execution is not supported there. See <<Concurrency,Concurrency with Kotest 6>> for what Kotest 6 offers.
+* **The extension is not made thread-safe by this.** The lock stops JUnit from entering the extension concurrently; it does not make api:test.extensions.AbstractMicronautExtension[] safe to drive from threads you start yourself inside a test.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,7 @@ junit5:
   junit5RefreshingInjectedBeansBasedOnRequiresUponPropertiesChanges: Refreshing injected beans based on `@Requires` upon properties changes
   junit5TestingExternalServers: Testing External Servers
   junit5TestMethodsInjection: Test Methods Injection
+  junit5ParallelExecution: Parallel Test Execution
 kotest:
   title: Testing with Kotest
   settingUpKoTest: Setting up Kotest

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -11,7 +11,11 @@ tasks.withType(Test).configureEach {
     reports.html.required = !System.getenv("GITHUB_ACTION")
     reports.junitXml.required = true
 
-    useJUnitPlatform()
+    useJUnitPlatform {
+        // Fixtures under io.micronaut.test.junit5.parallel are only executed by
+        // MicronautTestParallelExecutionTest, through its own JUnit Platform launcher.
+        excludeTags("parallel-fixture")
+    }
 }
 
 configurations {
@@ -45,6 +49,7 @@ dependencies {
     testAnnotationProcessor(mn.micronaut.inject.java)
     testAnnotationProcessor(mn.micronaut.graal)
     testImplementation(libs.managed.junit.jupiter.params)
+    testImplementation(libs.managed.junit.platform.testkit)
     testImplementation(mn.kotlin.stdlib)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
@@ -76,4 +81,12 @@ graalvmNative {
 
 tasks.named("test") {
     systemProperty("mockito.test.enabled", "true")
+    // Runs this module's own suite under JUnit parallel execution, to check the resource lock
+    // against real tests rather than only against the fixtures. For example:
+    //   ./gradlew :micronaut-test-junit5:test -PparallelMode=concurrent -PparallelClassesMode=concurrent
+    if (project.hasProperty("parallelMode")) {
+        systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+        systemProperty("junit.jupiter.execution.parallel.mode.default", project.property("parallelMode"))
+        systemProperty("junit.jupiter.execution.parallel.mode.classes.default", project.hasProperty("parallelClassesMode") ? project.property("parallelClassesMode") : "same_thread")
+    }
 }

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautTestResourceLocksProvider.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautTestResourceLocksProvider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5;
+
+import io.micronaut.core.annotation.Internal;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Serialises everything that shares a single Micronaut test {@code ApplicationContext}.
+ *
+ * <p>A {@code @MicronautTest} class owns one extension instance, one application context and one set
+ * of singleton beans (including {@code @MockBean}s) for the whole class, and {@code @Nested} classes
+ * reuse the extension instance of their outermost enclosing class. Running the methods of such a group
+ * concurrently therefore races on shared mutable state. This provider hands every method - and every
+ * nested container - a lock keyed on the outermost test class, so JUnit still runs different
+ * {@code @MicronautTest} classes in parallel while keeping one context single-threaded.</p>
+ *
+ * <p>Two escape hatches exist for tests that are known to be thread-safe:</p>
+ * <ul>
+ *     <li>declare {@link Execution @Execution(CONCURRENT)} directly on the test class, which opts that
+ *     class out;</li>
+ *     <li>set {@code -Dmicronaut.test.parallel.methods=true}, which opts the whole JVM out.</li>
+ * </ul>
+ *
+ * <p>In both cases the test class, its beans and any {@code TestExecutionListener} on its classpath
+ * become the author's responsibility.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+@Internal
+public final class MicronautTestResourceLocksProvider implements ResourceLocksProvider {
+
+    /**
+     * System property that disables the per-context lock for the whole JVM.
+     */
+    public static final String PARALLEL_METHODS_PROPERTY = "micronaut.test.parallel.methods";
+
+    private static final String KEY_PREFIX = "micronaut.test.context:";
+
+    @Override
+    public Set<Lock> provideForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
+        return locksFor(enclosingInstanceTypes, testClass);
+    }
+
+    @Override
+    public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod) {
+        return locksFor(enclosingInstanceTypes, testClass);
+    }
+
+    private static Set<Lock> locksFor(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
+        if (Boolean.getBoolean(PARALLEL_METHODS_PROPERTY)) {
+            return Set.of();
+        }
+        Class<?> owner = enclosingInstanceTypes == null || enclosingInstanceTypes.isEmpty()
+            ? testClass
+            : enclosingInstanceTypes.get(0);
+        if (isConcurrentByDeclaration(owner)) {
+            return Set.of();
+        }
+        return Set.of(new Lock(KEY_PREFIX + owner.getName()));
+    }
+
+    /**
+     * Whether the class itself asks for concurrent execution. Only a directly declared annotation
+     * counts: an execution mode that merely comes from a configuration parameter says nothing about
+     * whether the class was written to be thread-safe.
+     *
+     * @param testClass The outermost test class
+     * @return true if the class opts out of the per-context lock
+     */
+    private static boolean isConcurrentByDeclaration(Class<?> testClass) {
+        Execution execution = testClass.getDeclaredAnnotation(Execution.class);
+        return execution != null && execution.value() == ExecutionMode.CONCURRENT;
+    }
+}

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/annotation/MicronautTest.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/annotation/MicronautTest.java
@@ -22,7 +22,9 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.test.annotation.TransactionMode;
 import io.micronaut.test.condition.TestActiveCondition;
 import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import io.micronaut.test.extensions.junit5.MicronautTestResourceLocksProvider;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -40,6 +42,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @ExtendWith(MicronautJunit5Extension.class)
+@ResourceLock(providers = MicronautTestResourceLocksProvider.class)
 @Factory
 @Inherited
 @Requires(condition = TestActiveCondition.class)

--- a/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/reflect-config.json
+++ b/test-junit5/src/main/resources/META-INF/native-image/io.micronaut.test/micronaut-test-junit5/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "io.micronaut.test.extensions.junit5.MicronautTestResourceLocksProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/test-junit5/src/test/java/io/micronaut/test/extensions/junit5/MicronautTestResourceLocksProviderTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/extensions/junit5/MicronautTestResourceLocksProviderTest.java
@@ -1,0 +1,130 @@
+package io.micronaut.test.extensions.junit5;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
+import org.junit.jupiter.api.parallel.Resources;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// theOptOutRemovesEveryLock sets a system property that the provider reads, so these methods must
+// not run alongside each other - or alongside anything else touching system properties - when this
+// module's own suite is run with -PparallelMode=concurrent.
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+class MicronautTestResourceLocksProviderTest {
+
+    private final MicronautTestResourceLocksProvider provider = new MicronautTestResourceLocksProvider();
+
+    @Test
+    void micronautTestDeclaresTheProvider() {
+        ResourceLock resourceLock = AnnotationSupport.findAnnotation(MicronautTest.class, ResourceLock.class)
+            .orElseThrow(() -> new AssertionError("@MicronautTest no longer declares a @ResourceLock"));
+        assertEquals(1, resourceLock.providers().length);
+        assertSame(MicronautTestResourceLocksProvider.class, resourceLock.providers()[0]);
+    }
+
+    @Test
+    void classesAreNotLockedSoTheyStillRunInParallel() {
+        assertTrue(provider.provideForClass(Outer.class).isEmpty());
+    }
+
+    @Test
+    void methodsAreLockedOnTheirOwnClass() throws NoSuchMethodException {
+        Method method = Outer.class.getDeclaredMethod("test");
+
+        assertEquals(
+            Set.of(new ResourceLocksProvider.Lock("micronaut.test.context:" + Outer.class.getName(),
+                ResourceAccessMode.READ_WRITE)),
+            provider.provideForMethod(List.of(), Outer.class, method));
+    }
+
+    @Test
+    void nestedMethodsAreLockedOnTheOutermostClass() throws NoSuchMethodException {
+        Method method = Outer.Inner.class.getDeclaredMethod("test");
+
+        assertEquals(
+            Set.of(new ResourceLocksProvider.Lock("micronaut.test.context:" + Outer.class.getName())),
+            provider.provideForMethod(List.of(Outer.class), Outer.Inner.class, method));
+    }
+
+    @Test
+    void nestedClassesAreLockedOnTheOutermostClass() {
+        assertEquals(
+            Set.of(new ResourceLocksProvider.Lock("micronaut.test.context:" + Outer.class.getName())),
+            provider.provideForNestedClass(List.of(Outer.class), Outer.Inner.class));
+    }
+
+    @Test
+    void theOptOutRemovesEveryLock() throws NoSuchMethodException {
+        Method method = Outer.class.getDeclaredMethod("test");
+        System.setProperty(MicronautTestResourceLocksProvider.PARALLEL_METHODS_PROPERTY, "true");
+        try {
+            assertTrue(provider.provideForMethod(List.of(), Outer.class, method).isEmpty());
+            assertTrue(provider.provideForNestedClass(List.of(Outer.class), Outer.Inner.class).isEmpty());
+        } finally {
+            System.clearProperty(MicronautTestResourceLocksProvider.PARALLEL_METHODS_PROPERTY);
+        }
+    }
+
+    @Test
+    void aClassDeclaringConcurrentExecutionIsNotLocked() throws NoSuchMethodException {
+        Method method = ConcurrentOuter.class.getDeclaredMethod("test");
+
+        assertTrue(provider.provideForMethod(List.of(), ConcurrentOuter.class, method).isEmpty());
+        assertTrue(provider.provideForNestedClass(List.of(ConcurrentOuter.class), Outer.Inner.class).isEmpty());
+    }
+
+    @Test
+    void aClassDeclaringSameThreadExecutionIsStillLocked() throws NoSuchMethodException {
+        Method method = SameThreadOuter.class.getDeclaredMethod("test");
+
+        assertEquals(
+            Set.of(new ResourceLocksProvider.Lock("micronaut.test.context:" + SameThreadOuter.class.getName())),
+            provider.provideForMethod(List.of(), SameThreadOuter.class, method));
+    }
+
+    // The classes below are never executed. They exist so that the tests above have a Class and a
+    // Method to hand to the provider, which is a pure function of the two; their bodies are empty
+    // because nothing about them is ever run.
+
+    @Execution(ExecutionMode.CONCURRENT)
+    static class ConcurrentOuter {
+
+        void test() {
+            // A method handle for the provider, never invoked.
+        }
+    }
+
+    @Execution(ExecutionMode.SAME_THREAD)
+    static class SameThreadOuter {
+
+        void test() {
+            // A method handle for the provider, never invoked.
+        }
+    }
+
+    static class Outer {
+
+        void test() {
+            // A method handle for the provider, never invoked.
+        }
+
+        static class Inner {
+
+            void test() {
+                // A method handle for the provider, never invoked.
+            }
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaNoRollbackTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaNoRollbackTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest(rollback = false)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:JpaNoRollbackTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JpaNoRollbackTest {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaRollbackTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaRollbackTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:JpaRollbackTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 public class JpaRollbackTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionMultipleSetupsTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionMultipleSetupsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(transactionMode = TransactionMode.SINGLE_TRANSACTION)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:JpaSingleTransactionMultipleSetupsTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 public class JpaSingleTransactionMultipleSetupsTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionNoSetupTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionNoSetupTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(transactionMode = TransactionMode.SINGLE_TRANSACTION)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:JpaSingleTransactionNoSetupTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 public class JpaSingleTransactionNoSetupTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSingleTransactionTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(transactionMode = TransactionMode.SINGLE_TRANSACTION)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:JpaSingleTransactionTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 public class JpaSingleTransactionTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/NonTransactionalTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/NonTransactionalTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @MicronautTest(transactional = false)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:NonTransactionalTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 class NonTransactionalTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceApplicationStopTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceApplicationStopTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Property(name = "datasources.default.dialect", value = "H2")
 @Property(name = "datasources.default.driverClassName", value = "org.h2.Driver")
 @Property(name = "datasources.default.schema-generate", value = "CREATE_DROP")
-@Property(name = "datasources.default.url", value = "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
+@Property(name = "datasources.default.url", value = "jdbc:h2:mem:SqlDatasourceApplicationStopTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @Property(name = "datasources.default.username", value = "sa")
 @Sql({"classpath:create.sql", "classpath:datasource_1_insert.sql"}) // <1>
 class SqlDatasourceApplicationStopTest {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/SqlDatasourceTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Property(name = "datasources.default.dialect", value = "H2")
 @Property(name = "datasources.default.driverClassName", value = "org.h2.Driver")
 @Property(name = "datasources.default.schema-generate", value = "CREATE_DROP")
-@Property(name = "datasources.default.url", value = "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
+@Property(name = "datasources.default.url", value = "jdbc:h2:mem:SqlDatasourceTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @Property(name = "datasources.default.username", value = "sa")
 
 @Sql({"classpath:create.sql", "classpath:datasource_1_insert.sql"}) // <1>

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyExplicitTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalDefaultPropertyExplicitTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Map;
 
 @MicronautTest(transactional = true)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:TransactionalDefaultPropertyExplicitTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TransactionalDefaultPropertyExplicitTest implements TestPropertyProvider {

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/TransactionalTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @MicronautTest(transactional = true)
+@io.micronaut.context.annotation.Property(name = "datasources.default.url", value = "jdbc:h2:mem:TransactionalTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
 @DbProperties
 class TransactionalTest {
 

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ConcurrencyRecorder.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ConcurrencyRecorder.java
@@ -1,0 +1,74 @@
+package io.micronaut.test.junit5.parallel;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Records how many test executions sharing a key were in flight at the same time.
+ *
+ * <p>Fixtures call {@link #record} from their test methods; the driver test then asserts on the
+ * observed maximum. A maximum of {@code 1} proves the executions were serialised.</p>
+ */
+final class ConcurrencyRecorder {
+
+    private static final ConcurrentMap<String, Counters> COUNTERS = new ConcurrentHashMap<>();
+
+    private ConcurrencyRecorder() {
+    }
+
+    static void reset(String key) {
+        COUNTERS.remove(key);
+    }
+
+    /**
+     * Marks the calling thread as active for {@code key} and keeps it there for {@code holdMillis},
+     * so that anything else entering the same key in that window is observed.
+     *
+     * <p>The thread is parked rather than slept: this is not waiting for something to happen, it is
+     * deliberately occupying the window in which an overlap would show up.</p>
+     *
+     * @param key        the key being guarded
+     * @param holdMillis how long to occupy the window
+     * @return how many executions were inside {@code key} when this one entered, itself included -
+     *     1 when the executions are properly serialised
+     */
+    static int hold(String key, long holdMillis) {
+        Counters counters = COUNTERS.computeIfAbsent(key, k -> new Counters());
+        counters.invocations.incrementAndGet();
+        counters.threads.add(Thread.currentThread().getName());
+        int active = counters.active.incrementAndGet();
+        counters.max.accumulateAndGet(active, Math::max);
+        try {
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(holdMillis));
+            return Math.max(active, counters.active.get());
+        } finally {
+            counters.active.decrementAndGet();
+        }
+    }
+
+    static int maxConcurrency(String key) {
+        Counters counters = COUNTERS.get(key);
+        return counters == null ? 0 : counters.max.get();
+    }
+
+    static int invocations(String key) {
+        Counters counters = COUNTERS.get(key);
+        return counters == null ? 0 : counters.invocations.get();
+    }
+
+    static int distinctThreads(String key) {
+        Counters counters = COUNTERS.get(key);
+        return counters == null ? 0 : counters.threads.size();
+    }
+
+    private static final class Counters {
+        private final AtomicInteger active = new AtomicInteger();
+        private final AtomicInteger max = new AtomicInteger();
+        private final AtomicInteger invocations = new AtomicInteger();
+        private final Set<String> threads = ConcurrentHashMap.newKeySet();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ConcurrentMethodsFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ConcurrentMethodsFixture.java
@@ -1,0 +1,31 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A class that declares {@code @Execution(CONCURRENT)} itself opts out of the per-context lock and
+ * takes responsibility for its own thread safety - nothing here touches shared context state.
+ */
+@MicronautTest
+@Execution(ExecutionMode.CONCURRENT)
+@Tag(ParallelFixtures.TAG)
+class ConcurrentMethodsFixture {
+
+    static final String KEY = "concurrent-methods";
+
+    @Test
+    void one() {
+        assertTrue(Rendezvous.meet(KEY), ParallelFixtures.MUST_MEET);
+    }
+
+    @Test
+    void two() {
+        assertTrue(Rendezvous.meet(KEY), ParallelFixtures.MUST_MEET);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ContextIdentity.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ContextIdentity.java
@@ -1,0 +1,21 @@
+package io.micronaut.test.junit5.parallel;
+
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A singleton whose identity distinguishes one application context from the next, used to detect a
+ * test holding beans from a context that has already been torn down and rebuilt.
+ */
+@Singleton
+class ContextIdentity {
+
+    private static final AtomicInteger SEQUENCE = new AtomicInteger();
+
+    private final int id = SEQUENCE.incrementAndGet();
+
+    int getId() {
+        return id;
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/DefaultGreeter.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/DefaultGreeter.java
@@ -1,0 +1,15 @@
+package io.micronaut.test.junit5.parallel;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Default {@link Greeter} implementation, replaced by a mock in {@link MockBeanFixture}.
+ */
+@Singleton
+class DefaultGreeter implements Greeter {
+
+    @Override
+    public String greet() {
+        return "real";
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/EmbeddedServerFixtureOne.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/EmbeddedServerFixtureOne.java
@@ -1,0 +1,40 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two classes that each start their own embedded server must be able to run at the same time, on
+ * their own ports, against their own contexts.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+@Property(name = "spec.name", value = "EmbeddedServerFixture")
+class EmbeddedServerFixtureOne {
+
+    static final String KEY = "embedded-server";
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void servesItsOwnServerWhileTheOtherClassRuns() {
+        assertTrue(embeddedServer.isRunning());
+        assertTrue(Rendezvous.meet(KEY), ParallelFixtures.MUST_MEET);
+        assertEquals("pong", client.toBlocking().retrieve(HttpRequest.GET("/parallel/ping")));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/EmbeddedServerFixtureTwo.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/EmbeddedServerFixtureTwo.java
@@ -1,0 +1,37 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @see EmbeddedServerFixtureOne
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+@Property(name = "spec.name", value = "EmbeddedServerFixture")
+class EmbeddedServerFixtureTwo {
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void servesItsOwnServerWhileTheOtherClassRuns() {
+        assertTrue(embeddedServer.isRunning());
+        assertTrue(Rendezvous.meet(EmbeddedServerFixtureOne.KEY), ParallelFixtures.MUST_MEET);
+        assertEquals("pong", client.toBlocking().retrieve(HttpRequest.GET("/parallel/ping")));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/Greeter.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/Greeter.java
@@ -1,0 +1,9 @@
+package io.micronaut.test.junit5.parallel;
+
+/**
+ * Collaborator used by the {@code @MockBean} fixture.
+ */
+interface Greeter {
+
+    String greet();
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ListenerPairingFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ListenerPairingFixture.java
@@ -1,0 +1,39 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @see PairingListener
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+@Property(name = "spec.name", value = "ListenerPairingFixture")
+class ListenerPairingFixture {
+
+    static final String KEY = "listener-pairing";
+
+    @Test
+    void one() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void two() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void three() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void four() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MethodPropertyFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MethodPropertyFixture.java
@@ -1,0 +1,66 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A method level {@code @Property} mutates the extension's shared {@code testProperties} map and then
+ * refreshes the shared {@code Environment}, so overlapping methods see each other's values.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class MethodPropertyFixture {
+
+    @Inject
+    Config config;
+
+    @Test
+    @Property(name = "parallel.value", value = "alpha")
+    void alpha() {
+        assertValue("alpha");
+    }
+
+    @Test
+    @Property(name = "parallel.value", value = "bravo")
+    void bravo() {
+        assertValue("bravo");
+    }
+
+    @Test
+    @Property(name = "parallel.value", value = "charlie")
+    void charlie() {
+        assertValue("charlie");
+    }
+
+    @Test
+    @Property(name = "parallel.value", value = "delta")
+    void delta() {
+        assertValue("delta");
+    }
+
+    private void assertValue(String expected) {
+        assertEquals(expected, config.getValue());
+        assertEquals(1, ConcurrencyRecorder.hold("method-property", 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals(expected, config.getValue(), "property changed underneath the running test");
+    }
+
+    @ConfigurationProperties("parallel")
+    static class Config {
+
+        private String value = "unset";
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MicronautTestParallelExecutionTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MicronautTestParallelExecutionTest.java
@@ -1,0 +1,206 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.MicronautTestResourceLocksProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runs the fixtures in this package through a second, fully parallel JUnit Jupiter engine and
+ * asserts the guarantees Micronaut Test makes about them.
+ *
+ * <p>The contract under test is: everything sharing one {@code @MicronautTest} application context
+ * runs single-threaded, while separate {@code @MicronautTest} classes run at the same time.</p>
+ *
+ * @see io.micronaut.test.extensions.junit5.MicronautTestResourceLocksProvider
+ */
+@Isolated("starts its own parallel JUnit engine and toggles a global system property")
+// Every test here drives the fixtures through a second JUnit Platform launcher, selecting them by
+// class at run time. A native image resolves its tests at build time instead, from a fixed list, so
+// a nested launcher discovers nothing and every run comes back empty.
+@DisabledInNativeImage
+class MicronautTestParallelExecutionTest {
+
+    @Test
+    @DisplayName("methods of one @MicronautTest class never overlap")
+    void methodsOfOneClassAreSerialized() {
+        ConcurrencyRecorder.reset(SharedContextFixture.KEY);
+
+        assertAllPassed(runInParallel(SharedContextFixture.class), 6);
+
+        assertEquals(6, ConcurrencyRecorder.invocations(SharedContextFixture.KEY));
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(SharedContextFixture.KEY),
+            "methods sharing one application context ran concurrently");
+    }
+
+    @Test
+    @DisplayName("@Nested methods never overlap with the enclosing class")
+    void nestedClassesAreSerializedWithTheirEnclosingClass() {
+        ConcurrencyRecorder.reset(NestedClassFixture.KEY);
+
+        assertAllPassed(runInParallel(NestedClassFixture.class), 5);
+
+        assertEquals(5, ConcurrencyRecorder.invocations(NestedClassFixture.KEY));
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(NestedClassFixture.KEY),
+            "a @Nested class ran concurrently with the extension instance it shares");
+    }
+
+    @Test
+    @DisplayName("parameterized, repeated and dynamic invocations never overlap")
+    void testTemplateInvocationsAreSerialized() {
+        ConcurrencyRecorder.reset(TestTemplateFixture.KEY);
+
+        assertAllPassed(runInParallel(TestTemplateFixture.class), 12);
+
+        assertEquals(12, ConcurrencyRecorder.invocations(TestTemplateFixture.KEY));
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(TestTemplateFixture.KEY),
+            "test template invocations sharing one application context ran concurrently");
+    }
+
+    @Test
+    @DisplayName("separate @MicronautTest classes do run at the same time")
+    void separateClassesRunInParallel() {
+        Rendezvous.expect(SeparateContextsFixtureOne.KEY, 2);
+
+        assertAllPassed(runInParallel(SeparateContextsFixtureOne.class, SeparateContextsFixtureTwo.class), 2);
+    }
+
+    @Test
+    @DisplayName("separate embedded servers start and serve concurrently")
+    void separateEmbeddedServersRunInParallel() {
+        Rendezvous.expect(EmbeddedServerFixtureOne.KEY, 2);
+
+        assertAllPassed(runInParallel(EmbeddedServerFixtureOne.class, EmbeddedServerFixtureTwo.class), 2);
+    }
+
+    @Test
+    @DisplayName("a @MockBean is not shared by two running methods")
+    void mockBeansAreNotSharedConcurrently() {
+        ConcurrencyRecorder.reset("mock-bean");
+
+        assertAllPassed(runInParallel(MockBeanFixture.class), 6);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency("mock-bean"));
+    }
+
+    @Test
+    @DisplayName("a method level @Property is not visible to another running method")
+    void methodPropertiesDoNotLeakBetweenMethods() {
+        ConcurrencyRecorder.reset("method-property");
+
+        assertAllPassed(runInParallel(MethodPropertyFixture.class), 4);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency("method-property"));
+    }
+
+    @Test
+    @DisplayName("rebuildContext does not tear down a context a method is still using")
+    void rebuiltContextsAreNotSharedConcurrently() {
+        ConcurrencyRecorder.reset("rebuild-context");
+
+        assertAllPassed(runInParallel(RebuildContextFixture.class), 4);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency("rebuild-context"));
+    }
+
+    @Test
+    @DisplayName("a PER_CLASS TestPropertyProvider survives parallel execution")
+    void testPropertyProviderIsSerialized() {
+        ConcurrencyRecorder.reset(TestPropertyProviderFixture.KEY);
+
+        assertAllPassed(runInParallel(TestPropertyProviderFixture.class), 3);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(TestPropertyProviderFixture.KEY));
+    }
+
+    @Test
+    @DisplayName("@Sql BEFORE_EACH and AFTER_EACH phases do not interleave")
+    void sqlPhasesDoNotInterleave() {
+        ConcurrencyRecorder.reset("sql-phase");
+
+        assertAllPassed(runInParallel(SqlPhaseFixture.class), 4);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency("sql-phase"));
+    }
+
+    @Test
+    @DisplayName("parameter resolution stays correct under parallel execution")
+    void parameterResolutionIsSerialized() {
+        ConcurrencyRecorder.reset(ParameterResolutionFixture.KEY);
+
+        assertAllPassed(runInParallel(ParameterResolutionFixture.class), 4);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(ParameterResolutionFixture.KEY));
+    }
+
+    @Test
+    @DisplayName("TestExecutionListener callbacks never nest")
+    void listenerCallbacksNeverNest() {
+        ConcurrencyRecorder.reset(ListenerPairingFixture.KEY);
+        PairingListener.reset();
+
+        assertAllPassed(runInParallel(ListenerPairingFixture.class), 4);
+
+        assertEquals(1, ConcurrencyRecorder.maxConcurrency(ListenerPairingFixture.KEY));
+        assertEquals(1, PairingListener.MAX_DEPTH.get(),
+            "beforeTestMethod/afterTestMethod overlapped, so listener state cannot be per-method");
+        assertEquals(0, PairingListener.DEPTH.get(), "listener callbacks were not balanced");
+    }
+
+    @Test
+    @DisplayName("a class declaring @Execution(CONCURRENT) opts out of the lock")
+    void aClassCanOptOutOfSerialization() {
+        Rendezvous.expect(ConcurrentMethodsFixture.KEY, 2);
+
+        assertAllPassed(runInParallel(ConcurrentMethodsFixture.class), 2);
+    }
+
+    @Test
+    @DisplayName("without the lock the very same fixture does overlap")
+    void theSerializationAssertionsAreNotVacuous() {
+        ConcurrencyRecorder.reset(SharedContextFixture.KEY);
+
+        System.setProperty(MicronautTestResourceLocksProvider.PARALLEL_METHODS_PROPERTY, "true");
+        try {
+            runInParallel(SharedContextFixture.class);
+        } finally {
+            System.clearProperty(MicronautTestResourceLocksProvider.PARALLEL_METHODS_PROPERTY);
+        }
+
+        assertEquals(6, ConcurrencyRecorder.invocations(SharedContextFixture.KEY));
+        assertTrue(ConcurrencyRecorder.maxConcurrency(SharedContextFixture.KEY) > 1,
+            "the engine never ran two methods at once, so the serialization assertions prove nothing");
+        assertTrue(ConcurrencyRecorder.distinctThreads(SharedContextFixture.KEY) > 1,
+            "the engine never used a second thread, so the serialization assertions prove nothing");
+    }
+
+    private static EngineExecutionResults runInParallel(Class<?>... fixtures) {
+        DiscoverySelector[] selectors = Arrays.stream(fixtures)
+            .map(DiscoverySelectors::selectClass)
+            .toArray(DiscoverySelector[]::new);
+        return EngineTestKit.engine("junit-jupiter")
+            .enableImplicitConfigurationParameters(false)
+            .selectors(selectors)
+            .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.default", "concurrent")
+            .configurationParameter("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
+            .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
+            .configurationParameter("junit.jupiter.execution.parallel.config.fixed.parallelism", "4")
+            .execute();
+    }
+
+    private static void assertAllPassed(EngineExecutionResults results, int expected) {
+        results.testEvents().assertStatistics(stats -> stats.started(expected).succeeded(expected).failed(0));
+        results.containerEvents().assertStatistics(stats -> stats.failed(0));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MockBeanFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/MockBeanFixture.java
@@ -1,0 +1,40 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A {@code @MockBean} is a singleton of the per-class application context, so concurrent methods
+ * would stub and verify the very same mock. Each invocation here stubs a distinct answer and then
+ * verifies exactly one interaction, which only holds if the invocations do not overlap.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class MockBeanFixture {
+
+    @Inject
+    Greeter greeter;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"})
+    void eachInvocationOwnsTheMock(String expected) {
+        when(greeter.greet()).thenReturn(expected);
+        assertEquals(1, ConcurrencyRecorder.hold("mock-bean", 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals(expected, greeter.greet());
+        verify(greeter).greet();
+    }
+
+    @MockBean(DefaultGreeter.class)
+    Greeter greeter() {
+        return mock(Greeter.class);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/NestedClassFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/NestedClassFixture.java
@@ -1,0 +1,52 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A {@code @Nested} class reuses the extension instance of its outermost enclosing class, so its
+ * methods must be serialised against the outer class's methods too - not just against each other.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class NestedClassFixture {
+
+    static final String KEY = "nested-class";
+
+    @Test
+    void outerOne() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void outerTwo() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Nested
+    class Inner {
+
+        @Test
+        void innerOne() {
+            assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+        }
+
+        @Test
+        void innerTwo() {
+            assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+        }
+
+        @Nested
+        class Innermost {
+
+            @Test
+            void innermost() {
+                assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+            }
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/PairingListener.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/PairingListener.java
@@ -1,0 +1,37 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.context.TestContext;
+import io.micronaut.test.context.TestExecutionListener;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A {@link TestExecutionListener} is a singleton of the test's application context. Any state it
+ * keeps between {@code beforeTestMethod} and {@code afterTestMethod} - as Micronaut Data's
+ * transaction listener does with its {@code TransactionStatus} - is corrupted once two methods of
+ * the class overlap. This listener simply records how deeply the callbacks nest.
+ */
+@Singleton
+@Requires(property = "spec.name", value = "ListenerPairingFixture")
+class PairingListener implements TestExecutionListener {
+
+    static final AtomicInteger DEPTH = new AtomicInteger();
+    static final AtomicInteger MAX_DEPTH = new AtomicInteger();
+
+    static void reset() {
+        DEPTH.set(0);
+        MAX_DEPTH.set(0);
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) {
+        MAX_DEPTH.accumulateAndGet(DEPTH.incrementAndGet(), Math::max);
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) {
+        DEPTH.decrementAndGet();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ParallelFixtures.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ParallelFixtures.java
@@ -1,0 +1,26 @@
+package io.micronaut.test.junit5.parallel;
+
+/**
+ * Shared constants for the parallel-execution fixtures.
+ */
+final class ParallelFixtures {
+
+    /**
+     * Fixtures carry this tag so that the normal build excludes them; they are only ever run from
+     * {@code MicronautTestParallelExecutionTest} through the JUnit Platform test kit.
+     */
+    static final String TAG = "parallel-fixture";
+
+    /**
+     * Asserted by every fixture that must not overlap, so a failure names the method that did.
+     */
+    static final String NO_OVERLAP = "another execution sharing this application context ran at the same time";
+
+    /**
+     * Asserted by every fixture that must overlap.
+     */
+    static final String MUST_MEET = "the other participants never arrived, so these executions did not overlap";
+
+    private ParallelFixtures() {
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ParameterResolutionFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/ParameterResolutionFixture.java
@@ -1,0 +1,53 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Parameter resolution reads the extension's {@code applicationContext} and {@code testAnnotationValue}
+ * fields on the calling thread, so it has to stay correct while other methods of the class are in
+ * flight.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+@Property(name = "parallel.injected", value = "injected-value")
+@Property(name = "parallel.other", value = "other-value")
+class ParameterResolutionFixture {
+
+    static final String KEY = "parameter-resolution";
+
+    @Test
+    void resolvesApplicationContext(ApplicationContext applicationContext) {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 30), ParallelFixtures.NO_OVERLAP);
+        assertNotNull(applicationContext);
+        assertSame(applicationContext, applicationContext.getBean(ApplicationContext.class));
+    }
+
+    @Test
+    void resolvesValue(@Value("${parallel.injected}") String value) {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals("injected-value", value);
+    }
+
+    @Test
+    void resolvesProperty(@Property(name = "parallel.injected") String value,
+                          @Property(name = "parallel.other") String other) {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals("injected-value", value);
+        assertEquals("other-value", other);
+    }
+
+    @Test
+    void resolvesBean(Greeter greeter) {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals("real", greeter.greet());
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/PingController.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/PingController.java
@@ -1,0 +1,18 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+/**
+ * Endpoint used by the embedded server fixtures.
+ */
+@Controller("/parallel")
+@Requires(property = "spec.name", value = "EmbeddedServerFixture")
+class PingController {
+
+    @Get("/ping")
+    String ping() {
+        return "pong";
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/RebuildContextFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/RebuildContextFixture.java
@@ -1,0 +1,57 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code rebuildContext = true} stops and replaces the application context in {@code beforeEach}. A
+ * concurrent method would either be injected from the context that is about to be destroyed or find
+ * its own context stopped mid-test.
+ */
+@MicronautTest(rebuildContext = true)
+@Tag(ParallelFixtures.TAG)
+class RebuildContextFixture {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    ContextIdentity injectedIdentity;
+
+    @Test
+    void one() {
+        assertOwnContext();
+    }
+
+    @Test
+    void two() {
+        assertOwnContext();
+    }
+
+    @Test
+    void three() {
+        assertOwnContext();
+    }
+
+    @Test
+    void four() {
+        assertOwnContext();
+    }
+
+    private void assertOwnContext() {
+        assertTrue(applicationContext.isRunning(), "context was stopped while the test was running");
+        assertSame(applicationContext.getBean(ContextIdentity.class), injectedIdentity,
+            "injected bean came from a different application context");
+        assertEquals(1, ConcurrencyRecorder.hold("rebuild-context", 30), ParallelFixtures.NO_OVERLAP);
+        assertTrue(applicationContext.isRunning(), "context was stopped while the test was running");
+        assertSame(applicationContext.getBean(ContextIdentity.class), injectedIdentity,
+            "the application context was rebuilt while the test was running");
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/Rendezvous.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/Rendezvous.java
@@ -1,0 +1,50 @@
+package io.micronaut.test.junit5.parallel;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A meeting point used to prove that executions really do overlap.
+ *
+ * <p>If the participants are serialised the first one to arrive times out and the test fails, so a
+ * passing rendezvous is positive evidence of parallelism rather than of its absence.</p>
+ */
+final class Rendezvous {
+
+    private static final ConcurrentMap<String, CyclicBarrier> BARRIERS = new ConcurrentHashMap<>();
+    private static final long TIMEOUT_SECONDS = 30;
+
+    private Rendezvous() {
+    }
+
+    static void expect(String key, int parties) {
+        BARRIERS.put(key, new CyclicBarrier(parties));
+    }
+
+    /**
+     * Waits for the other participants of {@code key} to arrive.
+     *
+     * @param key the rendezvous to join
+     * @return true if every participant arrived, false if this one waited alone until the timeout -
+     *     which is what a serialised execution looks like
+     */
+    static boolean meet(String key) {
+        CyclicBarrier barrier = BARRIERS.get(key);
+        if (barrier == null) {
+            throw new IllegalStateException("No rendezvous registered for " + key);
+        }
+        try {
+            barrier.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            return true;
+        } catch (TimeoutException | BrokenBarrierException e) {
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SeparateContextsFixtureOne.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SeparateContextsFixtureOne.java
@@ -1,0 +1,23 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Paired with {@link SeparateContextsFixtureTwo} to prove that serialising one context does not
+ * serialise the whole suite: two different {@code @MicronautTest} classes must still overlap.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class SeparateContextsFixtureOne {
+
+    static final String KEY = "separate-contexts";
+
+    @Test
+    void meetsTheOtherClass() {
+        assertTrue(Rendezvous.meet(KEY), ParallelFixtures.MUST_MEET);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SeparateContextsFixtureTwo.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SeparateContextsFixtureTwo.java
@@ -1,0 +1,20 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @see SeparateContextsFixtureOne
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class SeparateContextsFixtureTwo {
+
+    @Test
+    void meetsTheOtherClass() {
+        assertTrue(Rendezvous.meet(SeparateContextsFixtureOne.KEY), ParallelFixtures.MUST_MEET);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SharedContextFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SharedContextFixture.java
@@ -1,0 +1,48 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every method of one {@code @MicronautTest} class shares a single extension instance and a single
+ * application context, so none of them may run at the same time.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class SharedContextFixture {
+
+    static final String KEY = "shared-context";
+
+    @Test
+    void one() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void two() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void three() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void four() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void five() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @Test
+    void six() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 50), ParallelFixtures.NO_OVERLAP);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SqlPhaseFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/SqlPhaseFixture.java
@@ -1,0 +1,71 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.annotation.Sql;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code @Sql} scripts for the {@code BEFORE_EACH} and {@code AFTER_EACH} phases run against the one
+ * datasource of the shared context, so overlapping methods would insert into each other's fixtures.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+@Property(name = "datasources.default.dialect", value = "H2")
+@Property(name = "datasources.default.driverClassName", value = "org.h2.Driver")
+@Property(name = "datasources.default.username", value = "sa")
+@Property(name = "datasources.default.url",
+    value = "jdbc:h2:mem:SqlPhaseFixture;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
+@Sql(value = "classpath:parallel/create.sql", phase = Sql.Phase.BEFORE_ALL)
+@Sql(value = "classpath:parallel/insert.sql", phase = Sql.Phase.BEFORE_EACH)
+@Sql(value = "classpath:parallel/delete.sql", phase = Sql.Phase.AFTER_EACH)
+class SqlPhaseFixture {
+
+    @Inject
+    DataSource dataSource;
+
+    @Test
+    void one() throws SQLException {
+        assertExactlyOneRow();
+    }
+
+    @Test
+    void two() throws SQLException {
+        assertExactlyOneRow();
+    }
+
+    @Test
+    void three() throws SQLException {
+        assertExactlyOneRow();
+    }
+
+    @Test
+    void four() throws SQLException {
+        assertExactlyOneRow();
+    }
+
+    private void assertExactlyOneRow() throws SQLException {
+        assertEquals(1, countRows(), "another test inserted into the shared datasource");
+        assertEquals(1, ConcurrencyRecorder.hold("sql-phase", 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals(1, countRows(), "another test inserted into the shared datasource");
+    }
+
+    private int countRows() throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement("select count(*) from ParallelRow");
+             ResultSet resultSet = statement.executeQuery()) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/TestPropertyProviderFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/TestPropertyProviderFixture.java
@@ -1,0 +1,54 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link TestPropertyProvider} requires the {@code PER_CLASS} lifecycle, which means one test
+ * instance is shared by every method of the class.
+ */
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag(ParallelFixtures.TAG)
+class TestPropertyProviderFixture implements TestPropertyProvider {
+
+    static final String KEY = "test-property-provider";
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Map.of("parallel.provided", "provided-value");
+    }
+
+    @Test
+    void one() {
+        assertProvidedProperty();
+    }
+
+    @Test
+    void two() {
+        assertProvidedProperty();
+    }
+
+    @Test
+    void three() {
+        assertProvidedProperty();
+    }
+
+    private void assertProvidedProperty() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 30), ParallelFixtures.NO_OVERLAP);
+        assertEquals("provided-value",
+            applicationContext.getEnvironment().getRequiredProperty("parallel.provided", String.class));
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/TestTemplateFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/parallel/TestTemplateFixture.java
@@ -1,0 +1,44 @@
+package io.micronaut.test.junit5.parallel;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Parameterized tests, repeated tests and dynamic tests reach the extension through
+ * {@code interceptTestTemplateMethod} and {@code interceptTestFactoryMethod} rather than
+ * {@code interceptTestMethod}; their invocations must be serialised on the same terms.
+ */
+@MicronautTest
+@Tag(ParallelFixtures.TAG)
+class TestTemplateFixture {
+
+    static final String KEY = "test-template";
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void parameterized(int value) {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @RepeatedTest(4)
+    void repeated() {
+        assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP);
+    }
+
+    @TestFactory
+    List<DynamicTest> dynamic() {
+        return IntStream.range(0, 4)
+            .mapToObj(i -> DynamicTest.dynamicTest("dynamic-" + i, () -> assertEquals(1, ConcurrencyRecorder.hold(KEY, 40), ParallelFixtures.NO_OVERLAP)))
+            .toList();
+    }
+}

--- a/test-junit5/src/test/resources/parallel/create.sql
+++ b/test-junit5/src/test/resources/parallel/create.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS ParallelRow (
+    NAME VARCHAR(255)
+);

--- a/test-junit5/src/test/resources/parallel/delete.sql
+++ b/test-junit5/src/test/resources/parallel/delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM ParallelRow;

--- a/test-junit5/src/test/resources/parallel/insert.sql
+++ b/test-junit5/src/test/resources/parallel/insert.sql
@@ -1,0 +1,1 @@
+INSERT INTO ParallelRow (NAME) VALUES ('row');


### PR DESCRIPTION
## What

Makes `@MicronautTest` safe under JUnit's [parallel execution](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution), which today produces silently wrong results.

Two guarantees:

* different `@MicronautTest` classes run **at the same time**, each with its own application context and embedded server;
* everything sharing **one** application context runs **one at a time**.

## Why

A `@MicronautTest` class owns one `ApplicationContext` for the whole class, so its beans — every `@MockBean` included — are singletons shared by all its methods. Method-level `@Property` state, `rebuildContext`, `@Sql` phases and `TestExecutionListener` state are per-class too, and `@Nested` classes reuse the extension instance of their outermost enclosing class.

Turning on parallelism against this module's own suite today:

| Mode | Failing classes |
|---|---|
| Baseline (sequential) | 0 |
| `mode.classes.default=concurrent` | 3 |
| `mode.default=concurrent` | 10 |

The method-level failures are mocks stubbed by one test and verified by another (`TooManyActualInvocations`), one method seeing another's `@Property` value, and Micronaut Data's `DefaultTestTransactionExecutionListener` — which holds a single `TransactionStatus` field — shared across concurrent methods.

## How

JUnit 5.12 added `@ResourceLock(providers = ...)`, which computes lock keys at runtime. `@MicronautTest` now declares a lock keyed on the **outermost** test class, so unrelated classes are never serialised against each other.

Two escape hatches for classes that really are thread-safe:

* `@Execution(CONCURRENT)` **declared directly on the class** opts that class out. Only a directly-declared annotation counts — a mode inherited from a configuration parameter says nothing about whether the class was written to be thread-safe;
* `-Dmicronaut.test.parallel.methods=true` opts out the whole JVM.

## ⚠️ Requires JUnit 5.12+

`ResourceLock#providers` did not exist before 5.12, and `ResourceLock#value()` had no default. On JUnit 5.11.4 the **entire Jupiter engine aborts** for any `@MicronautTest` class, sequential ones included:

```
JUnitException: TestEngine with ID 'junit-jupiter' failed to execute tests
  at jdk.proxy2/jdk.proxy2.$Proxy8.value(Unknown Source)
```

Verified against 5.11.4 (fails) and 5.12.2 (passes) with an isolated reproduction. The BOM manages 6.1.3 and even the 4.10.x line managed 5.14.0, so this only affects users who override `junit-bom` downward — but it is a breaking change worth a release note.

I also tried the obvious workaround, adding an explicit `value` alongside `providers`. It does fix 5.11.4, and on modern JUnit it destroys the whole feature: both locks then apply, the cross-class rendezvous tests time out, and the opt-out stops working. The fallback and the feature are mutually exclusive.

## Tests

`MicronautTestParallelExecutionTest` runs tagged fixtures through a second, fully parallel Jupiter engine via `junit-platform-testkit` and asserts **both** halves of the contract — that methods sharing a context never overlap, and that separate classes genuinely do (via a rendezvous that fails if they don't).

A negative control runs the same fixture with the lock disabled and asserts the overlap *does* happen, so the serialization assertions can't pass vacuously.

Fixtures cover shared context, `@MockBean`, method `@Property`, `rebuildContext`, `@Sql` phases, `TestPropertyProvider`, parameter resolution, `@TestTemplate`, `@Nested`, embedded servers, and listener pairing. They carry a `parallel-fixture` tag so the normal build skips them.

`-PparallelMode` on the `test` task runs this module's real suite under parallel execution:

```
./gradlew :micronaut-test-junit5:test -PparallelMode=concurrent -PparallelClassesMode=concurrent
```

## Also included

The `@DbProperties` tests all shared one H2 database (`testdb`), and two `Sql*` tests both created `MyTable` in `mem:devDb`, so they collided as soon as classes ran concurrently. Each now gets its own database. This is a test-fixture fix, not a framework one, but the suite can't demonstrate the feature without it.

## Verification

* `test-junit5`: **144 tests, 0 failures** sequentially and with classes *and* methods concurrent.
* `kotest5`, `spock`, `rest-assured`, `core`: green.
* `checkstyleMain` / `checkstyleTest` clean; `docs` builds.

New guide page **Testing with JUnit 5 → Parallel Test Execution** covers setup, a parallel-safety checklist, the opt-outs, and the limitations — including that this is JUnit-only; Spock and Kotest share the same extension state and carry no lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)