### PR TITLE
Close three JUnit Jupiter integration gaps

### DIFF
--- a/src/main/docs/guide/junit5/junit5TestLifecycle.adoc
+++ b/src/main/docs/guide/junit5/junit5TestLifecycle.adoc
@@ -1,0 +1,113 @@
+=== Observing test outcomes
+
+api:test.context.TestExecutionListener[] beans are notified as a test class runs. Alongside the `before*`/`after*` callbacks, four callbacks report how each test actually ended:
+
+[source,java]
+----
+@Singleton
+public class OutcomeListener implements TestExecutionListener {
+
+    @Override
+    public void testSuccessful(TestContext testContext) { }
+
+    @Override
+    public void testFailed(TestContext testContext) {       // <1>
+        report(testContext.getTestException());
+    }
+
+    @Override
+    public void testAborted(TestContext testContext) { }    // <2>
+
+    @Override
+    public void testDisabled(TestContext testContext, @Nullable String reason) { } // <3>
+}
+----
+<1> `getTestException()` holds the failure.
+<2> A test aborted by a failed assumption is not a failure. `getTestException()` holds the throwable that aborted it.
+<3> A disabled test never runs, so this is the *only* callback it produces - `beforeTestMethod` and `afterTestMethod` are never called for it.
+
+NOTE: These four callbacks are fired by the JUnit 5 integration. On Spock and Kotest they remain no-ops, so a listener shared across frameworks should not depend on them firing.
+
+=== Test instance lifecycle
+
+The test instance is injected from the application context, so `@PostConstruct` on a test class is called. `@PreDestroy` is called too, once per test instance - after each test method under the default `PER_METHOD` lifecycle, and once after the class under `@TestInstance(PER_CLASS)`. A test class may therefore acquire a resource in `@PostConstruct` and release it in `@PreDestroy`:
+
+[source,java]
+----
+@MicronautTest
+class ResourceTest {
+
+    private Path workspace;
+
+    @PostConstruct
+    void open() throws IOException {
+        workspace = Files.createTempDirectory("test");
+    }
+
+    @PreDestroy
+    void close() throws IOException {
+        Files.deleteIfExists(workspace);
+    }
+}
+----
+
+TIP: For a temporary directory specifically, prefer JUnit's own `@TempDir` - it works on a `@MicronautTest` class as a field or a parameter, and mixes freely with Micronaut-injected parameters in the same method signature.
+
+=== Sharing one application context with `@Nested`
+
+Every `@MicronautTest` class gets its own api:context.ApplicationContext[], started before the class and stopped after it. There is no context cache: two top-level classes with identical configuration get two contexts, and so does each subclass of an annotated base class.
+
+`@Nested` is the way to run several groups of tests against a single context. A nested class reuses the application context - and the beans, mocks and properties in it - of its outermost enclosing class, so an expensive context is paid for once no matter how many nested groups a class contains:
+
+[source,java]
+----
+@MicronautTest
+class OrderServiceTest {
+
+    @Inject
+    OrderService orderService;   // <1>
+
+    @Nested
+    class Placing {
+
+        @Test
+        void placesAnOrder() {
+        }
+    }
+
+    @Nested
+    class Cancelling {
+
+        @Test
+        void cancelsAnOrder() {   // <2>
+        }
+    }
+}
+----
+<1> Injected once, into the enclosing instance. Nested classes reach it through their enclosing instance.
+<2> Runs against the same context, the same singletons and the same `@MockBean` instances as every other test in the class.
+
+NOTE: Nesting is also how the same context is kept single-threaded under parallel execution - see <<junit5ParallelExecution,Parallel Test Execution>>, where a nested class locks on its outermost enclosing class.
+
+TIP: If the slow part of a test suite is a database or a container rather than the context itself, sharing that instead is usually the bigger win. See https://micronaut-projects.github.io/micronaut-test-resources/latest/guide/[Micronaut Test Resources].
+
+=== Configuration on `@Nested` classes
+
+Sharing the enclosing class's context has a consequence: configuration declared on the nested class itself has nowhere to go, so declaring it is an error:
+
+[source,java]
+----
+@MicronautTest
+class OuterTest {
+
+    @Nested
+    @Property(name = "some.key", value = "value")  // <1>
+    class Inner {
+    }
+}
+----
+<1> Rejected with an `ExtensionConfigurationException` naming both classes. The same applies to a second `@MicronautTest` on the nested class.
+
+A `@Nested` class that declares no configuration of its own is unaffected, and still gets the enclosing class's injected beans.
+
+IMPORTANT: Before Micronaut Test 5.2.0 these annotations were silently ignored, so a nested class appeared to be configured when it was not. Tests that relied on the ignored annotation were already running against the enclosing class's configuration; move the annotation to the enclosing class, or promote the nested class to a top-level test with its own `@MicronautTest`.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,7 @@ junit5:
   junit5RefreshingInjectedBeansBasedOnRequiresUponPropertiesChanges: Refreshing injected beans based on `@Requires` upon properties changes
   junit5TestingExternalServers: Testing External Servers
   junit5TestMethodsInjection: Test Methods Injection
+  junit5TestLifecycle: Test Lifecycle and Outcomes
   junit5ParallelExecution: Parallel Test Execution
 kotest:
   title: Testing with Kotest

--- a/test-core/src/main/java/io/micronaut/test/context/TestExecutionListener.java
+++ b/test-core/src/main/java/io/micronaut/test/context/TestExecutionListener.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.test.context;
 
+import io.micronaut.core.annotation.Nullable;
+
 /**
  * Test execution listener.
  *
@@ -121,6 +123,55 @@ public interface TestExecutionListener {
    * @throws Exception allows any exception to propagate
    */
   default void afterTestClass(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed when a test was never run because it was disabled.
+   *
+   * <p>None of the other callbacks fire for a disabled test, so this is the only notification a
+   * listener receives for it.</p>
+   *
+   * @param testContext the test context
+   * @param reason      the reason the test was disabled, if the test framework supplied one
+   * @throws Exception allows any exception to propagate
+   * @since 5.2.0
+   */
+  default void testDisabled(TestContext testContext, @Nullable String reason) throws Exception {
+
+  }
+
+  /**
+   * Executed after a test completed successfully.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   * @since 5.2.0
+   */
+  default void testSuccessful(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed after a test was aborted, for example by a failed assumption. An aborted test is not a
+   * failure; {@link TestContext#getTestException()} holds the throwable that aborted it.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   * @since 5.2.0
+   */
+  default void testAborted(TestContext testContext) throws Exception {
+
+  }
+
+  /**
+   * Executed after a test failed. {@link TestContext#getTestException()} holds the failure.
+   *
+   * @param testContext the test context
+   * @throws Exception allows any exception to propagate
+   * @since 5.2.0
+   */
+  default void testFailed(TestContext testContext) throws Exception {
 
   }
 

--- a/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
+++ b/test-core/src/main/java/io/micronaut/test/extensions/AbstractMicronautExtension.java
@@ -216,6 +216,30 @@ public abstract class AbstractMicronautExtension<C> implements TestExecutionList
     }
 
     @Override
+    public void testDisabled(TestContext testContext, String reason) throws Exception {
+        if (listeners != null) {
+            for (int i = listeners.size() - 1; i >= 0; i--) {
+                listeners.get(i).testDisabled(testContext, reason);
+            }
+        }
+    }
+
+    @Override
+    public void testSuccessful(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::testSuccessful, testContext, true);
+    }
+
+    @Override
+    public void testAborted(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::testAborted, testContext, true);
+    }
+
+    @Override
+    public void testFailed(TestContext testContext) throws Exception {
+        fireListeners(TestExecutionListener::testFailed, testContext, true);
+    }
+
+    @Override
     public void afterTestClass(TestContext testContext) throws Exception {
         fireListeners(TestExecutionListener::afterTestClass, testContext, true);
         if (specDefinition != null && applicationContext != null) {

--- a/test-junit5/build.gradle
+++ b/test-junit5/build.gradle
@@ -12,9 +12,10 @@ tasks.withType(Test).configureEach {
     reports.junitXml.required = true
 
     useJUnitPlatform {
-        // Fixtures under io.micronaut.test.junit5.parallel are only executed by
-        // MicronautTestParallelExecutionTest, through its own JUnit Platform launcher.
+        // Fixtures under io.micronaut.test.junit5.parallel and io.micronaut.test.junit5.lifecycle
+        // are executed only by the tests alongside them, through their own JUnit Platform launcher.
         excludeTags("parallel-fixture")
+        excludeTags("lifecycle-fixture")
     }
 }
 

--- a/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
+++ b/test-junit5/src/main/java/io/micronaut/test/extensions/junit5/MicronautJunit5Extension.java
@@ -57,7 +57,9 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
 import org.junit.jupiter.api.extension.TestInstantiationException;
+import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.reflect.AnnotatedElement;
@@ -78,13 +80,21 @@ import java.util.Optional;
  * @author graemerocher
  * @since 1.0
  */
-public class MicronautJunit5Extension extends AbstractMicronautExtension<ExtensionContext> implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, ExecutionCondition, BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver, InvocationInterceptor {
+public class MicronautJunit5Extension extends AbstractMicronautExtension<ExtensionContext> implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, ExecutionCondition, BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver, InvocationInterceptor, TestInstancePreDestroyCallback, TestWatcher {
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MicronautJunit5Extension.class);
     private static final String TEST_PROPERTY_PROVIDER_LIFECYCLE_MESSAGE = "Tests that implement TestPropertyProvider must use the PER_CLASS test instance lifecycle.";
+    private static final String NESTED_CONFIGURATION_MESSAGE = """
+        %s cannot be declared on the @Nested class %s. \
+        A nested class shares the application context of its enclosing class %s, so this \
+        configuration would be ignored rather than applied. \
+        Move it to %s, or make %s a top-level test class with its own @MicronautTest.""";
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
         final Class<?> testClass = extensionContext.getRequiredTestClass();
+        if (isNestedTestClass(testClass)) {
+            validateNestedTestClass(testClass);
+        }
         final TestInstance.Lifecycle testInstanceLifecycle = extensionContext.getTestInstanceLifecycle().orElse(TestInstance.Lifecycle.PER_METHOD);
         if (TestPropertyProvider.class.isAssignableFrom(testClass)) {
             if (testInstanceLifecycle != TestInstance.Lifecycle.PER_CLASS) {
@@ -222,6 +232,81 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             }
         });
         afterCleanupTest(testContext);
+    }
+
+    /**
+     * A nested class reuses the extension instance, application context and configuration of its
+     * outermost enclosing class, so configuration declared on the nested class itself has nowhere
+     * to go. Rather than ignoring it, say so.
+     *
+     * @param testClass the nested test class
+     */
+    private void validateNestedTestClass(Class<?> testClass) {
+        Class<?> enclosingClass = testClass.getEnclosingClass();
+        if (enclosingClass == null) {
+            return;
+        }
+        String annotation = null;
+        if (testClass.getDeclaredAnnotation(MicronautTest.class) != null) {
+            annotation = "@MicronautTest";
+        } else if (testClass.getDeclaredAnnotationsByType(Property.class).length > 0) {
+            annotation = "@Property";
+        }
+        if (annotation != null) {
+            throw new ExtensionConfigurationException(NESTED_CONFIGURATION_MESSAGE.formatted(
+                annotation,
+                testClass.getName(),
+                enclosingClass.getName(),
+                enclosingClass.getSimpleName(),
+                testClass.getSimpleName()));
+        }
+    }
+
+    @Override
+    public void preDestroyTestInstance(ExtensionContext extensionContext) {
+        if (applicationContext == null || !applicationContext.isRunning()) {
+            return;
+        }
+        extensionContext.getTestInstance().ifPresent(applicationContext::destroyBean);
+    }
+
+    @Override
+    public void testDisabled(ExtensionContext extensionContext, Optional<String> reason) {
+        fireOutcome(extensionContext, null, context -> testDisabled(context, reason.orElse(null)));
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext extensionContext) {
+        fireOutcome(extensionContext, null, context -> testSuccessful(context));
+    }
+
+    @Override
+    public void testAborted(ExtensionContext extensionContext, Throwable cause) {
+        fireOutcome(extensionContext, cause, context -> testAborted(context));
+    }
+
+    @Override
+    public void testFailed(ExtensionContext extensionContext, Throwable cause) {
+        fireOutcome(extensionContext, cause, context -> testFailed(context));
+    }
+
+    /**
+     * {@link TestWatcher} callbacks cannot throw a checked exception, and are also reached for tests
+     * that never started a context - a disabled class never runs {@code beforeAll}.
+     *
+     * @param extensionContext the extension context
+     * @param cause            the throwable that ended the test, if any
+     * @param callback         the listener callback to fire
+     */
+    private void fireOutcome(ExtensionContext extensionContext, Throwable cause, OutcomeCallback callback) {
+        if (applicationContext == null) {
+            return;
+        }
+        try {
+            callback.apply(buildContext(extensionContext, cause));
+        } catch (Exception e) {
+            throw new ExtensionConfigurationException("Error firing test outcome to a TestExecutionListener", e);
+        }
     }
 
     @Override
@@ -389,12 +474,16 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
     }
 
     private TestContext buildContext(ExtensionContext context) {
+        return buildContext(context, null);
+    }
+
+    private TestContext buildContext(ExtensionContext context, Throwable cause) {
         return new TestContext(
             applicationContext,
             context.getTestClass().orElse(null),
             context.getTestMethod().orElse(null),
             context.getTestInstance().orElse(null),
-            context.getExecutionException().orElse(null),
+            cause != null ? cause : context.getExecutionException().orElse(null),
             context.getDisplayName(),
             true);
     }
@@ -578,5 +667,14 @@ public class MicronautJunit5Extension extends AbstractMicronautExtension<Extensi
             }
         }
         return null;
+    }
+
+    /**
+     * A single {@link io.micronaut.test.context.TestExecutionListener} outcome callback.
+     */
+    @FunctionalInterface
+    private interface OutcomeCallback {
+
+        void apply(TestContext testContext) throws Exception;
     }
 }

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSeparateThreadTimeoutTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/JpaSeparateThreadTimeoutTest.java
@@ -1,0 +1,68 @@
+package io.micronaut.test.junit5;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.annotation.TransactionMode;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * JUnit runs the body of a {@code SEPARATE_THREAD} timeout on a thread of its own. Its built-in
+ * timeout interceptor is registered before the declarative Micronaut extension and therefore wraps
+ * it, so the Micronaut interceptor chain - and with it the test transaction - runs on that same
+ * thread. This test pins that ordering down: a change to it would silently take transactional
+ * isolation away from every timed test.
+ */
+@MicronautTest(transactionMode = TransactionMode.SINGLE_TRANSACTION)
+@DbProperties
+@Property(name = "datasources.default.url",
+    value = "jdbc:h2:mem:JpaSeparateThreadTimeoutTest;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")
+class JpaSeparateThreadTimeoutTest {
+
+    @Inject
+    EntityManager entityManager;
+
+    private String setUpThread;
+
+    @BeforeEach
+    void setUp() {
+        setUpThread = Thread.currentThread().getName();
+        Book book = new Book();
+        book.setTitle("written by setup");
+        entityManager.persist(book);
+    }
+
+    @Test
+    void sameThreadSeesTheSetupTransaction() {
+        assertEquals(setUpThread, Thread.currentThread().getName());
+        assertTrue(entityManager.isJoinedToTransaction());
+        assertEquals(1, countBooks());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void separateTimeoutThreadSeesTheSameTransaction() {
+        assertNotEquals(setUpThread, Thread.currentThread().getName(),
+            "JUnit did not move the test body onto its own timeout thread, so this test proves nothing");
+        assertTrue(entityManager.isJoinedToTransaction(),
+            "the test transaction did not reach the timeout thread");
+        assertEquals(1, countBooks(),
+            "the timeout thread ran outside the setup transaction");
+    }
+
+    private int countBooks() {
+        CriteriaQuery<Book> query = entityManager.getCriteriaBuilder().createQuery(Book.class);
+        query.from(Book.class);
+        return entityManager.createQuery(query).getResultList().size();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/Counter.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/Counter.java
@@ -1,0 +1,14 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import jakarta.inject.Singleton;
+
+/**
+ * A trivial collaborator, so the fixture is genuinely injected.
+ */
+@Singleton
+class Counter {
+
+    int value() {
+        return 1;
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/LifecycleFixtures.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/LifecycleFixtures.java
@@ -1,0 +1,16 @@
+package io.micronaut.test.junit5.lifecycle;
+
+/**
+ * Shared constants for the lifecycle fixtures.
+ */
+final class LifecycleFixtures {
+
+    /**
+     * Fixtures carry this tag so the normal build skips them; they are executed only by the tests in
+     * this package, through the JUnit Platform test kit.
+     */
+    static final String TAG = "lifecycle-fixture";
+
+    private LifecycleFixtures() {
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedConfigurationTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedConfigurationTest.java
@@ -1,0 +1,65 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Configuration declared on a {@code @Nested} class has nowhere to go, because the nested class
+ * shares its enclosing class's application context. Saying so beats ignoring it.
+ */
+// These drive fixtures through a second JUnit Platform launcher, selecting them by class at
+// run time. A native image resolves its tests at build time from a fixed list, so a nested
+// launcher discovers nothing.
+@DisabledInNativeImage
+class NestedConfigurationTest {
+
+    @Test
+    @DisplayName("@MicronautTest on a @Nested class is rejected with an explanation")
+    void nestedMicronautTestIsRejected() {
+        String message = failureMessage(NestedMicronautTestFixture.class);
+
+        assertTrue(message.contains("@MicronautTest cannot be declared on the @Nested class"), message);
+        assertTrue(message.contains(NestedMicronautTestFixture.Inner.class.getName()), message);
+        assertTrue(message.contains(NestedMicronautTestFixture.class.getName()), message);
+    }
+
+    @Test
+    @DisplayName("@Property on a @Nested class is rejected with an explanation")
+    void nestedPropertyIsRejected() {
+        String message = failureMessage(NestedPropertyFixture.class);
+
+        assertTrue(message.contains("@Property cannot be declared on the @Nested class"), message);
+        assertTrue(message.contains(NestedPropertyFixture.Inner.class.getName()), message);
+    }
+
+    @Test
+    @DisplayName("a @Nested class that declares no configuration still works")
+    void plainNestedClassesStillWork() {
+        run(PlainNestedFixture.class).testEvents()
+            .assertStatistics(stats -> stats.started(2).succeeded(2).failed(0));
+    }
+
+    private static String failureMessage(Class<?> fixture) {
+        Events containers = run(fixture).containerEvents();
+        containers.assertStatistics(stats -> stats.failed(1));
+        return containers.failed().stream()
+            .flatMap(event -> event.getPayload(org.junit.platform.engine.TestExecutionResult.class).stream())
+            .flatMap(result -> result.getThrowable().stream())
+            .map(Throwable::getMessage)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No container failure was recorded"));
+    }
+
+    private static org.junit.platform.testkit.engine.EngineExecutionResults run(Class<?> fixture) {
+        return EngineTestKit.engine("junit-jupiter")
+            .enableImplicitConfigurationParameters(false)
+            .selectors(DiscoverySelectors.selectClass(fixture))
+            .execute();
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedMicronautTestFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedMicronautTestFixture.java
@@ -1,0 +1,36 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A nested class cannot have its own context, so its own {@code @MicronautTest} must be rejected.
+ */
+@MicronautTest
+@Tag(LifecycleFixtures.TAG)
+class NestedMicronautTestFixture {
+
+    @Inject
+    Counter counter;
+
+    @Test
+    void outer() {
+        assertEquals(1, counter.value());
+    }
+
+    @Nested
+    @MicronautTest
+    class Inner {
+
+        @Test
+        void inner() {
+            fail("the nested class should have been rejected before any of its tests ran");
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedPropertyFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/NestedPropertyFixture.java
@@ -1,0 +1,38 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A @Property on a nested class used to be ignored without a word.
+ */
+@MicronautTest
+@Property(name = "lifecycle.scope", value = "outer")
+@Tag(LifecycleFixtures.TAG)
+class NestedPropertyFixture {
+
+    @Inject
+    Counter counter;
+
+    @Test
+    void outer() {
+        assertEquals(1, counter.value());
+    }
+
+    @Nested
+    @Property(name = "lifecycle.scope", value = "inner")
+    class Inner {
+
+        @Test
+        void inner() {
+            fail("the nested class should have been rejected before any of its tests ran");
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/PlainNestedFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/PlainNestedFixture.java
@@ -1,0 +1,34 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A nested class that declares no configuration of its own stays perfectly legal.
+ */
+@MicronautTest
+@Tag(LifecycleFixtures.TAG)
+class PlainNestedFixture {
+
+    @Inject
+    Counter counter;
+
+    @Test
+    void outer() {
+        assertEquals(1, counter.value());
+    }
+
+    @Nested
+    class Inner {
+
+        @Test
+        void inner() {
+            assertEquals(1, counter.value());
+        }
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/PreDestroyFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/PreDestroyFixture.java
@@ -1,0 +1,52 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A test class that opens something in {@code @PostConstruct} has to be able to close it again.
+ */
+@MicronautTest
+@Tag(LifecycleFixtures.TAG)
+class PreDestroyFixture {
+
+    static final List<String> EVENTS = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    Counter counter;
+
+    @PostConstruct
+    void open() {
+        EVENTS.add("postConstruct");
+    }
+
+    @PreDestroy
+    void close() {
+        EVENTS.add("preDestroy");
+    }
+
+    @Test
+    void first() {
+        EVENTS.add("test:first");
+        assertTrue(EVENTS.contains("postConstruct"), "the instance was not initialised before the test");
+        assertEquals(1, counter.value());
+    }
+
+    @Test
+    void second() {
+        EVENTS.add("test:second");
+        assertTrue(EVENTS.contains("postConstruct"), "the instance was not initialised before the test");
+        assertEquals(1, counter.value());
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestInstanceDestroyedTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestInstanceDestroyedTest.java
@@ -1,0 +1,42 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The test instance is a managed object: if Micronaut calls {@code @PostConstruct} on it, it has to
+ * call {@code @PreDestroy} too.
+ */
+// These drive fixtures through a second JUnit Platform launcher, selecting them by class at
+// run time. A native image resolves its tests at build time from a fixed list, so a nested
+// launcher discovers nothing.
+@DisabledInNativeImage
+class TestInstanceDestroyedTest {
+
+    @Test
+    @DisplayName("@PreDestroy runs once per test instance")
+    void testInstancesAreDestroyed() {
+        PreDestroyFixture.EVENTS.clear();
+
+        EngineTestKit.engine("junit-jupiter")
+            .enableImplicitConfigurationParameters(false)
+            .selectors(DiscoverySelectors.selectClass(PreDestroyFixture.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.started(2).succeeded(2).failed(0));
+
+        List<String> events = List.copyOf(PreDestroyFixture.EVENTS);
+
+        assertEquals(2, events.stream().filter("postConstruct"::equals).count(), events::toString);
+        assertEquals(2, events.stream().filter("preDestroy"::equals).count(),
+            () -> "@PreDestroy was not called for every test instance: " + events);
+        assertEquals(2, events.stream().filter(e -> e.startsWith("test:")).count(), events::toString);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeFixture.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeFixture.java
@@ -1,0 +1,48 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * One test per outcome. Run only by {@link TestOutcomeListenerTest}.
+ */
+@MicronautTest
+@Property(name = "spec.name", value = "TestOutcomeFixture")
+@Tag(LifecycleFixtures.TAG)
+class TestOutcomeFixture {
+
+    @Inject
+    Counter counter;
+
+    @Test
+    void passes() {
+        assertEquals(1, counter.value());
+    }
+
+    @Test
+    void fails() {
+        fail("expected failure");
+    }
+
+    @Test
+    void aborts() {
+        assertEquals(1, counter.value());
+        // Aborting is the outcome under test. The assertion above runs first, so the fixture is
+        // still checked to be wired up before the assumption ends the test.
+        Assumptions.assumeTrue(false, "aborted on purpose");
+    }
+
+    @Test
+    @Disabled("disabled on purpose")
+    void isDisabled() {
+        fail("a disabled test must never run");
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeListenerTest.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeListenerTest.java
@@ -1,0 +1,43 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code TestExecutionListener} sees every outcome, including the two that previously never
+ * reached it at all.
+ */
+// These drive fixtures through a second JUnit Platform launcher, selecting them by class at
+// run time. A native image resolves its tests at build time from a fixed list, so a nested
+// launcher discovers nothing.
+@DisabledInNativeImage
+class TestOutcomeListenerTest {
+
+    @Test
+    @DisplayName("every outcome reaches the listener")
+    void everyOutcomeIsReported() {
+        TestOutcomeRecorder.reset();
+
+        EngineTestKit.engine("junit-jupiter")
+            .enableImplicitConfigurationParameters(false)
+            .selectors(org.junit.platform.engine.discovery.DiscoverySelectors.selectClass(TestOutcomeFixture.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.succeeded(1).failed(1).aborted(1).skipped(1));
+
+        List<String> events = TestOutcomeRecorder.events();
+
+        assertTrue(events.contains("successful:passes()"), events::toString);
+        assertTrue(events.contains("failed:fails():AssertionFailedError"), events::toString);
+        assertTrue(events.contains("aborted:aborts():TestAbortedException"), events::toString);
+        assertTrue(events.contains("disabled:isDisabled():disabled on purpose"), events::toString);
+        assertEquals(4, events.size(), events::toString);
+    }
+}

--- a/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeRecorder.java
+++ b/test-junit5/src/test/java/io/micronaut/test/junit5/lifecycle/TestOutcomeRecorder.java
@@ -1,0 +1,52 @@
+package io.micronaut.test.junit5.lifecycle;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.context.TestContext;
+import io.micronaut.test.context.TestExecutionListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Records the outcome callbacks a {@link TestExecutionListener} receives.
+ */
+@Singleton
+@Requires(property = "spec.name", value = "TestOutcomeFixture")
+public class TestOutcomeRecorder implements TestExecutionListener {
+
+    private static final List<String> EVENTS = Collections.synchronizedList(new ArrayList<>());
+
+    public static void reset() {
+        EVENTS.clear();
+    }
+
+    public static List<String> events() {
+        synchronized (EVENTS) {
+            return List.copyOf(EVENTS);
+        }
+    }
+
+    @Override
+    public void testSuccessful(TestContext testContext) {
+        EVENTS.add("successful:" + testContext.getTestName());
+    }
+
+    @Override
+    public void testFailed(TestContext testContext) {
+        EVENTS.add("failed:" + testContext.getTestName() + ":"
+            + testContext.getTestException().getClass().getSimpleName());
+    }
+
+    @Override
+    public void testAborted(TestContext testContext) {
+        EVENTS.add("aborted:" + testContext.getTestName() + ":"
+            + testContext.getTestException().getClass().getSimpleName());
+    }
+
+    @Override
+    public void testDisabled(TestContext testContext, String reason) {
+        EVENTS.add("disabled:" + testContext.getTestName() + ":" + reason);
+    }
+}


### PR DESCRIPTION
## What

Jupiter exposes 21 behavioural extension SPIs. The integration used nine of them, and three of the gaps were visible to users.

## 1. A `TestExecutionListener` had no vocabulary for outcomes

A disabled test never reached a listener **at all** — `beforeTestMethod` and `afterTestMethod` are simply never called for it. An aborted test arrived through `getTestException()` as a `TestAbortedException`, indistinguishable from a failure except by `instanceof`.

`TestExecutionListener` now carries four more callbacks, fired from a `TestWatcher` bridge:

```java
@Singleton
public class OutcomeListener implements TestExecutionListener {

    @Override
    public void testSuccessful(TestContext testContext) { }

    @Override
    public void testFailed(TestContext testContext) { }

    @Override
    public void testAborted(TestContext testContext) { }

    @Override
    public void testDisabled(TestContext testContext, @Nullable String reason) { }
}
```

They are `default` methods, so existing listeners are unaffected, and they stay no-ops on Spock and Kotest, which have no equivalent hook. That is called out in the docs so a listener shared across frameworks does not come to depend on them.

## 2. `@PreDestroy` on a test class never ran

The test instance is injected from the application context, so `@PostConstruct` ran on it — but nothing ever destroyed it. A test class that acquired a resource in `@PostConstruct` leaked it. `TestInstancePreDestroyCallback` now destroys the test bean: once per instance under `PER_METHOD`, once per class under `@TestInstance(PER_CLASS)`.

**`TestInstancePostProcessor` was considered for the injection itself and deliberately not taken.** It fires before `beforeEach`, which is exactly where `rebuildContext = true` stops the context and builds a new one — injecting there would hand the test beans from a context that is about to be destroyed. Moving injection would mean relocating the rebuild too, which is a larger change than this PR should carry.

## 3. Configuration on a `@Nested` class was silently ignored

A nested class shares the extension instance and application context of its outermost enclosing class, so configuration declared on the nested class has nowhere to go. Previously `@Property` there was ignored without a word, and a second `@MicronautTest` left the enclosing instance uninjected and failed with an unexplained `NullPointerException`.

Both are now rejected in `beforeAll` with a message naming both classes:

> `@Property` cannot be declared on the `@Nested` class `…NestedPropertyFixture$Inner`. A nested class shares the application context of its enclosing class `…NestedPropertyFixture`, so this configuration would be ignored rather than applied. Move it to `NestedPropertyFixture`, or make `Inner` a top-level test class with its own `@MicronautTest`.

⚠️ **This is a breaking change.** A test that relied on the ignored annotation was already running against the enclosing class's configuration, so it was passing for the wrong reason; it now fails with an explanation. Nested classes that declare no configuration are unaffected, and `PlainNestedFixture` covers that.

## Also: pinning `@Timeout(threadMode = SEPARATE_THREAD)`

An earlier probe of mine reported this as escaping the test transaction. **That was wrong**, and worth recording. The probe ran under the default `SEPARATE_TRANSACTIONS` mode, where the `@BeforeEach` transaction is always committed by design, so setup rows accumulate between tests — the difference was ordering, not threading.

Re-probed under `SINGLE_TRANSACTION`, where every test must see exactly the one row setup wrote, the timeout thread behaves identically to the main thread. It works because JUnit registers its built-in `TimeoutExtension` before the declarative extension, so its interceptor wraps the Micronaut chain and the transaction runs *on* the timeout thread.

That ordering is load-bearing and undocumented, so `JpaSeparateThreadTimeoutTest` now asserts it. If a future JUnit or registration change reverses it, a test fails instead of transactional isolation quietly disappearing.

## Tests

Fixtures are tagged `lifecycle-fixture` and excluded from the normal run, then driven through their own JUnit Platform launcher — the same pattern as the parallel-execution tests in #1509. They carry `@DisabledInNativeImage`, because a native image resolves its test list at build time and a nested launcher discovers nothing.

## Verification

* **271 tests across all five modules, 0 failures**; `test-junit5` 137 → 144.
* `nativeTest` green locally under GraalVM CE 25.0.2: **101/101**.
* Parallel mode (`-PparallelMode=concurrent -PparallelClassesMode=concurrent`) green, so this does not regress #1509.
* `checkstyleMain` / `checkstyleTest` clean; `docs` builds.

New guide page **Testing with JUnit 5 → Test Lifecycle and Outcomes** documents all three, plus how `@Nested` is the way to share one application context across several groups of tests. The nested-class change carries an `IMPORTANT` note.

Follows #1509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)